### PR TITLE
Fix entrypoint permissions and address lint errors

### DIFF
--- a/src/components/ui/command.tsx
+++ b/src/components/ui/command.tsx
@@ -21,7 +21,8 @@ const Command = React.forwardRef<
 ))
 Command.displayName = CommandPrimitive.displayName
 
-interface CommandDialogProps extends DialogProps {}
+// Use a type alias instead of an empty interface to satisfy lint rules
+type CommandDialogProps = DialogProps
 
 const CommandDialog = ({ children, ...props }: CommandDialogProps) => {
   return (

--- a/src/components/ui/textarea.tsx
+++ b/src/components/ui/textarea.tsx
@@ -2,8 +2,8 @@ import * as React from "react"
 
 import { cn } from "@/lib/utils"
 
-export interface TextareaProps
-  extends React.TextareaHTMLAttributes<HTMLTextAreaElement> {}
+// Use a type alias instead of an empty interface to satisfy lint rules
+export type TextareaProps = React.TextareaHTMLAttributes<HTMLTextAreaElement>
 
 const Textarea = React.forwardRef<HTMLTextAreaElement, TextareaProps>(
   ({ className, ...props }, ref) => {

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -1,4 +1,5 @@
 import type { Config } from "tailwindcss";
+import animatePlugin from "tailwindcss-animate";
 
 export default {
 	darkMode: ["class"],
@@ -122,5 +123,5 @@ export default {
 			}
 		}
 	},
-	plugins: [require("tailwindcss-animate")],
+    plugins: [animatePlugin],
 } satisfies Config;

--- a/ubuntu-kde-docker/entrypoint.sh
+++ b/ubuntu-kde-docker/entrypoint.sh
@@ -16,7 +16,10 @@ echo "🚀 Starting Ubuntu KDE Marketing Agency WebTop..."
 
 # Initialize system directories
 mkdir -p /var/run/dbus /run/user/${DEV_UID} /tmp/.ICE-unix /tmp/.X11-unix
-chmod 1777 /tmp/.ICE-unix /tmp/.X11-unix
+# /tmp/.X11-unix may be mounted read-only by the host. Avoid failing if chmod
+# cannot modify permissions.
+chmod 1777 /tmp/.ICE-unix /tmp/.X11-unix 2>/dev/null || \
+  echo "⚠️  Warning: unable to set permissions on /tmp/.X11-unix"
 
 # Replace default username in polkit rule if different
 if [ -f /etc/polkit-1/rules.d/99-devuser-all.rules ]; then


### PR DESCRIPTION
## Summary
- guard chmod for readonly `/tmp/.X11-unix`
- convert empty interfaces to type aliases
- replace `require` in tailwind config with ES module import

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_b_688a701cf650832fa8704562e0bb5c6a