### PR TITLE
Fix supervisord polkitd environment

### DIFF
--- a/ubuntu-kde-docker/supervisord.conf
+++ b/ubuntu-kde-docker/supervisord.conf
@@ -18,7 +18,7 @@ priority=5
 autostart=true
 autorestart=true
 user=root
-environment=DBUS_SYSTEM_BUS_ADDRESS=unix:path=/run/dbus/system_bus_socket
+environment=DBUS_SYSTEM_BUS_ADDRESS="unix:path=/run/dbus/system_bus_socket"
 startretries=3
 startsecs=3
 


### PR DESCRIPTION
## Summary
- quote DBUS_SYSTEM_BUS_ADDRESS in supervisord config to fix parsing error

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_b_688a77939424832f8f473035a640520e