### PR TITLE
Fix Docker build errors caused by incorrect script paths

### DIFF
--- a/ubuntu-kde-docker/Dockerfile
+++ b/ubuntu-kde-docker/Dockerfile
@@ -162,7 +162,8 @@ COPY setup-wine.sh /usr/local/bin/setup-wine.sh
 COPY setup-waydroid.sh /usr/local/bin/setup-waydroid.sh
 COPY setup-video-editing.sh /usr/local/bin/setup-video-editing.sh
 COPY health-check.sh /usr/local/bin/health-check.sh
-RUN chmod +x /usr/local/bin/setup-*.sh /usr/local/bin/health-check.sh
+COPY fix-permissions.sh /usr/local/bin/fix-permissions.sh
+RUN chmod +x /usr/local/bin/setup-*.sh /usr/local/bin/health-check.sh /usr/local/bin/fix-permissions.sh
 
 COPY supervisord.conf /etc/supervisor/conf.d/supervisord.conf
 

--- a/ubuntu-kde-docker/supervisord.conf
+++ b/ubuntu-kde-docker/supervisord.conf
@@ -67,7 +67,7 @@ stopsignal=TERM
 user=root
 
 [program:SetupMarketing]
-command=/bin/sh -c 'sleep 5; /ubuntu-kde-docker/setup-marketing-shortcuts.sh'
+command=/bin/sh -c 'sleep 5; /usr/local/bin/setup-marketing-shortcuts.sh'
 priority=45
 autostart=true
 autorestart=false
@@ -92,7 +92,7 @@ stopsignal=TERM
 user=root
 
 [program:SetupWaydroid]
-command=/bin/sh -c 'sleep 8; /ubuntu-kde-docker/setup-waydroid.sh'
+command=/bin/sh -c 'sleep 8; /usr/local/bin/setup-waydroid.sh'
 priority=48
 autostart=true
 autorestart=false
@@ -101,7 +101,7 @@ user=root
 startretries=1
 
 [program:SetupVideoEditing]
-command=/bin/sh -c 'sleep 6; /ubuntu-kde-docker/setup-video-editing.sh'
+command=/bin/sh -c 'sleep 6; /usr/local/bin/setup-video-editing.sh'
 priority=49
 autostart=true
 autorestart=false
@@ -110,7 +110,7 @@ user=root
 startretries=1
 
 [program:FixPermissions]
-command=/ubuntu-kde-docker/fix-permissions.sh
+command=/usr/local/bin/fix-permissions.sh
 priority=99
 autostart=true
 autorestart=false


### PR DESCRIPTION
The supervisord configuration was attempting to execute scripts from `/ubuntu-kde-docker/`, but this directory does not exist in the Docker image. The scripts are actually copied to `/usr/local/bin/`.

This change corrects the paths in `supervisord.conf` to point to `/usr/local/bin/`.

Additionally, the `fix-permissions.sh` script was not being copied into the Docker image at all. This change adds the necessary `COPY` instruction to the `Dockerfile` to include this script and make it executable.