### PR TITLE
Fix supervisord service stability issues

### DIFF
--- a/ubuntu-kde-docker/supervisord.conf
+++ b/ubuntu-kde-docker/supervisord.conf
@@ -13,7 +13,7 @@ startretries=3
 startsecs=2
 
 [program:polkitd]
-command=/bin/sh -c 'timeout=30; while [ $timeout -gt 0 ] && ! [ -S /run/dbus/system_bus_socket ]; do echo "Waiting for D-Bus..."; sleep 1; timeout=$((timeout - 1)); done; if [ ! -S /run/dbus/system_bus_socket ]; then echo "D-Bus not available"; exit 1; fi; sleep 2; for p in /usr/lib/policykit-1/polkitd /usr/lib/polkit-1/polkitd /usr/libexec/policykit-1/polkitd; do [ -x "$p" ] && exec "$p" --no-debug; done; exit 1'
+command=/bin/sh -c 'while [ ! -S /run/dbus/system_bus_socket ]; do echo "Waiting for D-Bus..."; sleep 1; done; exec /usr/lib/polkit-1/polkitd --no-debug'
 priority=5
 autostart=true
 autorestart=true
@@ -32,7 +32,7 @@ user=%(ENV_DEV_USERNAME)s
 environment=DISPLAY=:1,HOME=/home/%(ENV_DEV_USERNAME)s,USER=%(ENV_DEV_USERNAME)s,XDG_RUNTIME_DIR=/run/user/%(ENV_DEV_UID)s
 
 [program:xpra]
-command=/bin/sh -c "sleep 10; exec /usr/bin/xpra shadow :1 --bind-tcp=0.0.0.0:14500 --html=on --daemon=no --speaker=on --microphone=on --sound-source=pulse:tcp:localhost:4713 --audio-codec=opus --speaker-codec=opus || /usr/bin/xpra shadow :1 --bind-tcp=0.0.0.0:14500 --html=on --daemon=no --no-speaker --no-microphone"
+command=/bin/sh -c "exec /usr/bin/xpra shadow :1 --bind-tcp=0.0.0.0:14500 --html=on --daemon=no --speaker=on --microphone=on --sound-source=pulse:tcp:localhost:4713 --audio-codec=opus --speaker-codec=opus || /usr/bin/xpra shadow :1 --bind-tcp=0.0.0.0:14500 --html=on --daemon=no --no-speaker --no-microphone"
 priority=35
 autostart=true
 autorestart=true
@@ -117,6 +117,7 @@ autorestart=false
 stopsignal=TERM
 user=root
 startretries=1
+exitcodes=0
 
 [program:sshd]
 command=/bin/sh -c 'mkdir -p /run/sshd; if ! /usr/sbin/sshd -t; then echo "SSH config test failed"; exit 1; fi; exec /usr/sbin/sshd -D -e'


### PR DESCRIPTION
- Corrected the `FixPermissions` service configuration in `supervisord.conf` by adding `exitcodes=0`. This prevents supervisord from treating the successful one-time execution of the script as a service failure.
- Simplified the `polkitd` service command to use a direct path and remove complex shell logic, making the service startup more reliable.
- Removed a `sleep` delay from the `xpra` service command, as the underlying race condition should be resolved by the `polkitd` fix.