### PR TITLE
I've made a commit that resolves several startup and stability issues…

### DIFF
--- a/ubuntu-kde-docker/setup-desktop.sh
+++ b/ubuntu-kde-docker/setup-desktop.sh
@@ -8,7 +8,7 @@ mkdir -p "${DESKTOP_DIR}"
 # Wait for flatpak apps to finish installing if flatpak is available
 if command -v flatpak >/dev/null 2>&1; then
     for _ in {1..10}; do
-        if flatpak list | grep -q "com.adobe.Reader"; then
+        if (flatpak list || true) | grep -q "com.adobe.Reader"; then
             break
         fi
         sleep 5

--- a/ubuntu-kde-docker/supervisord.conf
+++ b/ubuntu-kde-docker/supervisord.conf
@@ -13,7 +13,7 @@ startretries=3
 startsecs=2
 
 [program:polkitd]
-command=/bin/sh -c 'while [ ! -S /run/dbus/system_bus_socket ]; do echo "Waiting for D-Bus..."; sleep 1; done; exec /usr/lib/polkit-1/polkitd --no-debug'
+command=/bin/sh -c 'while [ ! -S /run/dbus/system_bus_socket ]; do echo "Waiting for D-Bus..."; sleep 1; done; sleep 2; exec /usr/lib/polkit-1/polkitd --no-debug'
 priority=5
 autostart=true
 autorestart=true
@@ -32,7 +32,7 @@ user=%(ENV_DEV_USERNAME)s
 environment=DISPLAY=:1,HOME=/home/%(ENV_DEV_USERNAME)s,USER=%(ENV_DEV_USERNAME)s,XDG_RUNTIME_DIR=/run/user/%(ENV_DEV_UID)s
 
 [program:xpra]
-command=/bin/sh -c "exec /usr/bin/xpra shadow :1 --bind-tcp=0.0.0.0:14500 --html=on --daemon=no --speaker=on --microphone=on --sound-source=pulse:tcp:localhost:4713 --audio-codec=opus --speaker-codec=opus || /usr/bin/xpra shadow :1 --bind-tcp=0.0.0.0:14500 --html=on --daemon=no --no-speaker --no-microphone"
+command=/bin/sh -c "sleep 5; exec /usr/bin/xpra shadow :1 --bind-tcp=0.0.0.0:14500 --html=on --daemon=no --speaker=on --microphone=on --sound-source=pulse:tcp:localhost:4713 --audio-codec=opus --speaker-codec=opus || /usr/bin/xpra shadow :1 --bind-tcp=0.0.0.0:14500 --html=on --daemon=no --no-speaker --no-microphone"
 priority=35
 autostart=true
 autorestart=true
@@ -54,7 +54,7 @@ user=root
 command=/usr/local/bin/setup-flatpak-apps.sh
 priority=30
 autostart=true
-autorestart=false
+autorestart=unexpected
 stopsignal=TERM
 user=root
 
@@ -62,7 +62,7 @@ user=root
 command=/usr/local/bin/setup-desktop.sh
 priority=40
 autostart=true
-autorestart=false
+autorestart=unexpected
 stopsignal=TERM
 user=root
 
@@ -70,16 +70,15 @@ user=root
 command=/bin/sh -c 'sleep 5; /usr/local/bin/setup-marketing-shortcuts.sh'
 priority=45
 autostart=true
-autorestart=false
+autorestart=unexpected
 stopsignal=TERM
 user=root
-startretries=1
 
 [program:SetupDevelopment]
 command=/usr/local/bin/setup-development.sh
 priority=46
 autostart=true
-autorestart=false
+autorestart=unexpected
 stopsignal=TERM
 user=root
 
@@ -87,7 +86,7 @@ user=root
 command=/usr/local/bin/setup-wine.sh
 priority=47
 autostart=true
-autorestart=false
+autorestart=unexpected
 stopsignal=TERM
 user=root
 
@@ -95,28 +94,25 @@ user=root
 command=/bin/sh -c 'sleep 8; /usr/local/bin/setup-waydroid.sh'
 priority=48
 autostart=true
-autorestart=false
+autorestart=unexpected
 stopsignal=TERM
 user=root
-startretries=1
 
 [program:SetupVideoEditing]
 command=/bin/sh -c 'sleep 6; /usr/local/bin/setup-video-editing.sh'
 priority=49
 autostart=true
-autorestart=false
+autorestart=unexpected
 stopsignal=TERM
 user=root
-startretries=1
 
 [program:FixPermissions]
 command=/usr/local/bin/fix-permissions.sh
 priority=99
 autostart=true
-autorestart=false
+autorestart=unexpected
 stopsignal=TERM
 user=root
-startretries=1
 exitcodes=0
 
 [program:sshd]


### PR DESCRIPTION
… in your Docker container environment managed by supervisord.

Here are the changes I made:

1.  **Corrected one-shot script handling in `supervisord.conf`**: The `autorestart` directive for all one-time setup scripts (e.g., `SetupDesktop`, `FixPermissions`) was changed from `false` to `unexpected`. This prevents supervisord from treating their successful completion as an error, which was causing them to enter a `FATAL` state.

2.  **Stabilized `polkitd` and `xpra` startup**:
    - A 2-second startup delay was added to the `polkitd` service to mitigate a race condition with the D-Bus daemon, which was likely causing `polkitd` to fail on startup.
    - A 5-second startup delay was added to the `xpra` service to ensure that the Xvnc server and Pulseaudio are fully initialized before `xpra` attempts to connect to them.

3.  **Improved `setup-desktop.sh` resiliency**: The `setup-desktop.sh` script was made more robust by modifying the `flatpak list` command. The command is now wrapped in a subshell with `|| true` to prevent the script from exiting if the `flatpak` service is not yet available, which was a likely cause of the `SetupDesktop` service failure.