### PR TITLE
Fix supervisord service stability issues

### DIFF
--- a/ubuntu-kde-docker/supervisord.conf
+++ b/ubuntu-kde-docker/supervisord.conf
@@ -19,8 +19,8 @@ autostart=true
 autorestart=true
 user=root
 environment=DBUS_SYSTEM_BUS_ADDRESS="unix:path=/run/dbus/system_bus_socket"
-startretries=2
-startsecs=5
+startretries=5
+startsecs=10
 
 [program:Xvnc]
 command=/bin/sh -c "vncserver -kill :1 2>/dev/null || true; rm -rf /tmp/.X1-lock /tmp/.X11-unix/X1; vncserver :1 -fg -geometry 1920x1080 -depth 24 -SecurityTypes None -xstartup /home/%(ENV_DEV_USERNAME)s/.vnc/xstartup"
@@ -30,6 +30,7 @@ autorestart=true
 stopsignal=TERM
 user=%(ENV_DEV_USERNAME)s
 environment=DISPLAY=:1,HOME=/home/%(ENV_DEV_USERNAME)s,USER=%(ENV_DEV_USERNAME)s,XDG_RUNTIME_DIR=/run/user/%(ENV_DEV_UID)s
+startsecs=5
 
 [program:xpra]
 command=/bin/sh -c "sleep 5; exec /usr/bin/xpra shadow :1 --bind-tcp=0.0.0.0:14500 --html=on --daemon=no --speaker=on --microphone=on --sound-source=pulse:tcp:localhost:4713 --audio-codec=opus --speaker-codec=opus || /usr/bin/xpra shadow :1 --bind-tcp=0.0.0.0:14500 --html=on --daemon=no --no-speaker --no-microphone"
@@ -39,8 +40,8 @@ autorestart=true
 stopsignal=TERM
 user=%(ENV_DEV_USERNAME)s
 environment=DISPLAY=:1,HOME=/home/%(ENV_DEV_USERNAME)s,USER=%(ENV_DEV_USERNAME)s,XDG_RUNTIME_DIR=/run/user/%(ENV_DEV_UID)s,PULSE_RUNTIME_PATH=/run/user/%(ENV_DEV_UID)s/pulse
-startretries=5
-startsecs=5
+startretries=10
+startsecs=10
 
 [program:noVNC]
 command=/usr/bin/websockify --web=/usr/share/novnc/ 80 localhost:5901
@@ -54,7 +55,7 @@ user=root
 command=/usr/local/bin/setup-flatpak-apps.sh
 priority=30
 autostart=true
-autorestart=unexpected
+autorestart=false
 stopsignal=TERM
 user=root
 
@@ -62,7 +63,7 @@ user=root
 command=/usr/local/bin/setup-desktop.sh
 priority=40
 autostart=true
-autorestart=unexpected
+autorestart=false
 stopsignal=TERM
 user=root
 
@@ -70,7 +71,7 @@ user=root
 command=/bin/sh -c 'sleep 5; /usr/local/bin/setup-marketing-shortcuts.sh'
 priority=45
 autostart=true
-autorestart=unexpected
+autorestart=false
 stopsignal=TERM
 user=root
 
@@ -78,7 +79,7 @@ user=root
 command=/usr/local/bin/setup-development.sh
 priority=46
 autostart=true
-autorestart=unexpected
+autorestart=false
 stopsignal=TERM
 user=root
 
@@ -86,7 +87,7 @@ user=root
 command=/usr/local/bin/setup-wine.sh
 priority=47
 autostart=true
-autorestart=unexpected
+autorestart=false
 stopsignal=TERM
 user=root
 
@@ -94,7 +95,7 @@ user=root
 command=/bin/sh -c 'sleep 8; /usr/local/bin/setup-waydroid.sh'
 priority=48
 autostart=true
-autorestart=unexpected
+autorestart=false
 stopsignal=TERM
 user=root
 
@@ -102,7 +103,7 @@ user=root
 command=/bin/sh -c 'sleep 6; /usr/local/bin/setup-video-editing.sh'
 priority=49
 autostart=true
-autorestart=unexpected
+autorestart=false
 stopsignal=TERM
 user=root
 
@@ -110,10 +111,9 @@ user=root
 command=/usr/local/bin/fix-permissions.sh
 priority=99
 autostart=true
-autorestart=unexpected
+autorestart=false
 stopsignal=TERM
 user=root
-exitcodes=0
 
 [program:sshd]
 command=/bin/sh -c 'mkdir -p /run/sshd; if ! /usr/sbin/sshd -t; then echo "SSH config test failed"; exit 1; fi; exec /usr/sbin/sshd -D -e'


### PR DESCRIPTION
The supervisord configuration was causing several services to fail and restart continuously. This was due to a combination of incorrect restart policies for one-shot scripts and race conditions between services with dependencies.

- Changed `autorestart` to `false` for all setup and permission-fixing scripts. These are one-shot tasks and should not be treated as long-running services.
- Increased `startsecs` and `startretries` for `polkitd`, `Xvnc`, and `xpra` to make them more resilient to startup race conditions.