### PR TITLE
Fix Xpra audio config

### DIFF
--- a/ubuntu-kde-docker/Dockerfile
+++ b/ubuntu-kde-docker/Dockerfile
@@ -158,19 +158,31 @@ COPY setup-video-editing.sh /usr/local/bin/setup-video-editing.sh
 COPY setup-ttyd.sh /usr/local/bin/setup-ttyd.sh
 COPY service-health.sh /usr/local/bin/service-health.sh
 COPY test-desktop-audio.sh /usr/local/bin/test-desktop-audio.sh
+COPY audio-validation.sh /usr/local/bin/audio-validation.sh
 COPY system-validation.sh /usr/local/bin/system-validation.sh
 COPY audio-monitor.sh /usr/local/bin/audio-monitor.sh
 COPY health-check.sh /usr/local/bin/health-check.sh
 COPY fix-permissions.sh /usr/local/bin/fix-permissions.sh
 COPY test-polkit.sh /usr/local/bin/test-polkit.sh
-RUN chmod +x /usr/local/bin/setup-*.sh /usr/local/bin/service-health.sh /usr/local/bin/test-desktop-audio.sh /usr/local/bin/audio-monitor.sh /usr/local/bin/health-check.sh /usr/local/bin/fix-permissions.sh /usr/local/bin/test-polkit.sh
+RUN chmod +x /usr/local/bin/setup-*.sh \
+    /usr/local/bin/service-health.sh \
+    /usr/local/bin/test-desktop-audio.sh \
+    /usr/local/bin/audio-monitor.sh \
+    /usr/local/bin/audio-validation.sh \
+    /usr/local/bin/health-check.sh \
+    /usr/local/bin/fix-permissions.sh \
+    /usr/local/bin/test-polkit.sh
 
 # Run TTYD setup to create wrapper script
 RUN /usr/local/bin/setup-ttyd.sh
 
 # Validate all scripts are present and executable
 RUN echo "Validating script dependencies..." && \
-    ls -la /usr/local/bin/setup-*.sh /usr/local/bin/service-health.sh /usr/local/bin/test-desktop-audio.sh /usr/local/bin/audio-monitor.sh
+    ls -la /usr/local/bin/setup-*.sh \
+    /usr/local/bin/service-health.sh \
+    /usr/local/bin/test-desktop-audio.sh \
+    /usr/local/bin/audio-monitor.sh \
+    /usr/local/bin/audio-validation.sh
 
 COPY supervisord.conf /etc/supervisor/conf.d/supervisord.conf
 

--- a/ubuntu-kde-docker/supervisord.conf
+++ b/ubuntu-kde-docker/supervisord.conf
@@ -82,7 +82,7 @@ autostart=true
 autorestart=true
 stopsignal=TERM
 user=%(ENV_DEV_USERNAME)s
-environment=DISPLAY=:1,HOME=/home/%(ENV_DEV_USERNAME)s,USER=%(ENV_DEV_USERNAME)s,XDG_RUNTIME_DIR=/run/user/%(ENV_DEV_UID)s,PULSE_SERVER=unix:/run/user/%(ENV_DEV_UID)s/pulse/native
+environment=DISPLAY=:1,HOME=/home/%(ENV_DEV_USERNAME)s,USER=%(ENV_DEV_USERNAME)s,XDG_RUNTIME_DIR=/run/user/%(ENV_DEV_UID)s,PULSE_SERVER=tcp:localhost:4713
 startsecs=20
 startretries=2
 stdout_logfile=/var/log/supervisor/xpra.log


### PR DESCRIPTION
## Summary
- include `audio-validation.sh` in the docker image and mark it executable
- check for `audio-validation.sh` when validating script dependencies
- use TCP based `PULSE_SERVER` for Xpra in `supervisord.conf`

## Testing
- `npm run lint`
- `npm run build`
- `npm run build:dev`

------
https://chatgpt.com/codex/tasks/task_b_688b4740467c832fb27712b6417eefe0