### PR TITLE
I've fixed a Docker build error by removing some conflicting packages.

### DIFF
--- a/ubuntu-kde-docker/Dockerfile
+++ b/ubuntu-kde-docker/Dockerfile
@@ -192,7 +192,7 @@ RUN /usr/local/bin/setup-ttyd.sh
 # Install additional dependencies for enhanced features
 RUN apt-get update && apt-get install -y \
     python3-pip python3-websockets python3-psutil python3-requests \
-    python3-schedule rclone imagemagick ffmpeg nodejs npm curl jq git \
+    python3-schedule rclone imagemagick ffmpeg \
     && pip3 install websockets psutil requests schedule aiohttp \
     && npm install -g ws express socket.io
 


### PR DESCRIPTION
The Docker build was failing because of a conflict between the `nodejs` package from NodeSource and the `npm` package from the default Ubuntu repositories.

The `nodejs` package from NodeSource already includes `npm`, so trying to install `npm` separately caused a conflict.

I've resolved the issue by removing `nodejs`, `npm`, `curl`, `jq`, and `git` from the `apt-get install` command in the Dockerfile, as these packages are already installed earlier in the build process.