### PR TITLE
Fix Dockerfile build errors

### DIFF
--- a/ubuntu-kde-docker/Dockerfile
+++ b/ubuntu-kde-docker/Dockerfile
@@ -98,6 +98,7 @@ RUN mkdir -p /etc/apt/keyrings \
     && apt-get update \
     && apt-get install -y \
         google-chrome-stable brave-browser opera-stable code \
+    && rm /etc/apt/sources.list.d/opera.list \
     && apt-get clean && rm -rf /var/lib/apt/lists/*
 
 # Allow running Chromium-based browsers as root
@@ -192,8 +193,7 @@ RUN /usr/local/bin/setup-ttyd.sh
 # Install additional dependencies for enhanced features
 RUN apt-get update && apt-get install -y \
     python3-pip python3-websockets python3-psutil python3-requests \
-    python3-schedule rclone imagemagick ffmpeg \
-    && pip3 install websockets psutil requests schedule aiohttp \
+    python3-schedule rclone imagemagick ffmpeg python3-aiohttp \
     && npm install -g ws express socket.io
 
 # Setup audio bridge


### PR DESCRIPTION
This commit fixes two issues in the Dockerfile that caused the build to fail or produce warnings.

1.  **Fix PEP 668 error during pip install:** The `pip3 install` command was failing with an `externally-managed-environment` error. This is because recent versions of Debian/Ubuntu prevent global package installation with pip to avoid conflicts with apt.

    The fix is to install all required Python packages using `apt`. `python3-aiohttp` was added to the `apt-get install` list, and the entire `pip3 install` command was removed, as all other packages were already being installed via apt.

2.  **Resolve duplicate APT repository warning for Opera:** A warning about a duplicate APT source for Opera was being shown during `apt-get update`. This was because a source list was added manually, and the `opera-stable` package also adds a source list upon installation.

    The fix is to remove the manually created `/etc/apt/sources.list.d/opera.list` file immediately after `opera-stable` is installed, which resolves the conflict.