### PR TITLE
Fix syntax error in entrypoint

### DIFF
--- a/ubuntu-kde-docker/entrypoint.sh
+++ b/ubuntu-kde-docker/entrypoint.sh
@@ -300,25 +300,24 @@ else
     if [ -f "/usr/local/bin/setup-wine.sh" ]; then
         if /usr/local/bin/setup-wine.sh; then
             log_info "Wine setup completed successfully"
-        
-        # Setup Google Ads Editor
-        if [ -f "/usr/local/bin/setup-google-ads-editor.sh" ]; then
-            if /usr/local/bin/setup-google-ads-editor.sh; then
-                log_info "Google Ads Editor setup completed successfully"
+
+            # Setup Google Ads Editor
+            if [ -f "/usr/local/bin/setup-google-ads-editor.sh" ]; then
+                if /usr/local/bin/setup-google-ads-editor.sh; then
+                    log_info "Google Ads Editor setup completed successfully"
+                else
+                    log_warn "Google Ads Editor setup failed"
+                fi
             else
-                log_warn "Google Ads Editor setup failed"
+                log_warn "Google Ads Editor setup script not found"
             fi
         else
-            log_warn "Google Ads Editor setup script not found"
+            log_warn "Wine setup failed"
         fi
     else
-        log_warn "Wine setup failed"
+        log_warn "Wine setup script not found"
     fi
-else
-    log_warn "Wine setup script not found"
 fi
-fi
-
 # Setup container Android solutions
 log_info "Setting up container Android..."
 if [ -f "/usr/local/bin/setup-android-container.sh" ]; then


### PR DESCRIPTION
## Summary
- remove stray `fi` in `entrypoint.sh`
- ensure Wine setup block has balanced conditionals

## Testing
- `bash -n ubuntu-kde-docker/entrypoint.sh`

------
https://chatgpt.com/codex/tasks/task_b_688c8e722e58832fbd27b230206c9479