### PR TITLE
Fix Google Ads Editor setup failure handling

### DIFF
--- a/ubuntu-kde-docker/entrypoint.sh
+++ b/ubuntu-kde-docker/entrypoint.sh
@@ -186,18 +186,24 @@ fi
 # Set up Wine for Windows applications
 log_info "Setting up Wine for Windows applications..."
 if [ -f "/usr/local/bin/setup-wine.sh" ]; then
-    /usr/local/bin/setup-wine.sh
-    echo "✅ Wine setup completed"
-    
-    # Set up Google Ads Editor after Wine is ready
-    if [ -f "/usr/local/bin/setup-google-ads-editor.sh" ]; then
-        /usr/local/bin/setup-google-ads-editor.sh
-        echo "✅ Google Ads Editor setup completed"
+    if /usr/local/bin/setup-wine.sh; then
+        log_info "Wine setup completed"
+
+        # Set up Google Ads Editor after Wine is ready with error handling
+        if [ -f "/usr/local/bin/setup-google-ads-editor.sh" ]; then
+            if /usr/local/bin/setup-google-ads-editor.sh; then
+                log_info "Google Ads Editor setup completed"
+            else
+                log_warn "Google Ads Editor setup failed (continuing)"
+            fi
+        else
+            log_warn "Google Ads Editor setup script not found"
+        fi
     else
-        echo "⚠️  Google Ads Editor setup script not found"
+        log_warn "Wine setup failed (continuing)"
     fi
 else
-    echo "⚠️  Wine setup script not found"
+    log_warn "Wine setup script not found"
 fi
 
 # Generate SSH host keys if they don't exist


### PR DESCRIPTION
## Summary
- use log functions for Wine and Google Ads Editor setup
- allow the entrypoint to continue if installation fails

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_b_688cb31edde8832fbb0e22d7578214e2