### PR TITLE
Fix missing font directory for KDE optimization

### DIFF
--- a/ubuntu-kde-docker/setup-kde-optimization.sh
+++ b/ubuntu-kde-docker/setup-kde-optimization.sh
@@ -143,6 +143,7 @@ Color=30,30,30
 EOF
 
 # Optimize font rendering for screen sharing
+sudo -u "$DEV_USERNAME" mkdir -p "${DEV_HOME}/.config/fontconfig"
 cat > "${DEV_HOME}/.config/fontconfig/fonts.conf" << 'EOF'
 <?xml version="1.0"?>
 <!DOCTYPE fontconfig SYSTEM "fonts.dtd">


### PR DESCRIPTION
## Summary
- ensure the fontconfig directory exists before writing `fonts.conf`

## Testing
- `npm install`
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_b_688cba84739c832f9660909a2c3aa1e0