### PR TITLE
Fix DBus startup and skip Android if unsupported

### DIFF
--- a/ubuntu-kde-docker/entrypoint.sh
+++ b/ubuntu-kde-docker/entrypoint.sh
@@ -290,10 +290,25 @@ if [ -f "/usr/local/bin/setup-container-dbus.sh" ]; then
     /usr/local/bin/setup-container-dbus.sh || log_warn "D-Bus setup failed"
 fi
 
+# Ensure D-Bus services are running so applications can connect
+if [ -f "/usr/local/bin/start-dbus" ]; then
+    /usr/local/bin/start-dbus || log_warn "Failed to start D-Bus services"
+fi
+
 # Setup font configuration early
 log_info "Setting up font configuration..."
 if [ -f "/usr/local/bin/setup-font-config.sh" ]; then
     /usr/local/bin/setup-font-config.sh || log_warn "Font config setup failed"
+fi
+
+# Guarantee fontconfig exists to avoid KDE errors
+if [ ! -f "/home/${DEV_USERNAME}/.config/fontconfig/fonts.conf" ]; then
+    mkdir -p "/home/${DEV_USERNAME}/.config/fontconfig"
+    cat > "/home/${DEV_USERNAME}/.config/fontconfig/fonts.conf" <<'EOF'
+<?xml version="1.0"?>
+<fontconfig></fontconfig>
+EOF
+    chown ${DEV_USERNAME}:${DEV_USERNAME} "/home/${DEV_USERNAME}/.config/fontconfig/fonts.conf"
 fi
 
 # Setup container-optimized Wine

--- a/ubuntu-kde-docker/setup-waydroid.sh
+++ b/ubuntu-kde-docker/setup-waydroid.sh
@@ -105,6 +105,20 @@ EOF
 # Main Android setup logic
 ANDROID_SOLUTION=""
 
+# Verify required kernel modules are available
+missing_mods=0
+for mod in binder_linux ashmem_linux; do
+    if ! lsmod | grep -q "^$mod" 2>/dev/null; then
+        log_warn "Kernel module $mod not loaded"
+        missing_mods=1
+    fi
+done
+
+if [ "$missing_mods" -eq 1 ]; then
+    log_warn "Android kernel support unavailable; skipping Android setup"
+    ANDROID_SOLUTION="none"
+else
+
 # Check if Waydroid is available
 if command -v waydroid >/dev/null 2>&1; then
     log_info "Waydroid found, attempting container setup..."
@@ -141,6 +155,7 @@ else
         log_warn "No Android solution available"
         ANDROID_SOLUTION="none"
     fi
+fi
 fi
 
 # Create desktop shortcuts based on available solution


### PR DESCRIPTION
## Summary
- start dbus automatically from entrypoint
- create default fontconfig if missing
- check for binder/ashmem modules and skip Android setup when absent

## Testing
- `npm install`
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_b_688cc0ccd9e4832fbcffd7ea6825ae3c