### PR TITLE
Fix entrypoint syntax and stabilize Wine setup

### DIFF
--- a/ubuntu-kde-docker/entrypoint.sh
+++ b/ubuntu-kde-docker/entrypoint.sh
@@ -412,8 +412,6 @@ else
     log_warn "⚠️  Service health monitoring script not found"
 fi
 
-fi
-
 # Setup KasmVNC
 log_info "Setting up KasmVNC..."
 if [ -f "/usr/local/bin/setup-kasmvnc.sh" ]; then

--- a/ubuntu-kde-docker/setup-wine-container.sh
+++ b/ubuntu-kde-docker/setup-wine-container.sh
@@ -12,7 +12,7 @@ mkdir -p "${DEV_HOME}/.wine/drive_c/windows/system32"
 mkdir -p "${DEV_HOME}/.wine/drive_c/Program Files"
 
 # Set ownership first
-chown -R "${DEV_USERNAME}:${DEV_USERNAME}" "${DEV_HOME}/.wine"
+chown -R "${DEV_USERNAME}:${DEV_USERNAME}" "${DEV_HOME}/.wine" 2>/dev/null || true
 
 # Configure Wine for container environment
 sudo -u "$DEV_USERNAME" bash << 'WINE_CONTAINER_SETUP'
@@ -111,6 +111,6 @@ EOF
 chmod +x "${DEV_HOME}/.local/bin/wine-diagnostics"
 
 # Set final ownership
-chown -R "${DEV_USERNAME}:${DEV_USERNAME}" "${DEV_HOME}"
+chown -R "${DEV_USERNAME}:${DEV_USERNAME}" "${DEV_HOME}" 2>/dev/null || true
 
 echo "✅ Container-optimized Wine setup complete"


### PR DESCRIPTION
## Summary
- remove stray `fi` causing entrypoint restart loops
- make Wine setup ownership changes tolerant of temporary files

## Testing
- `bash -n ubuntu-kde-docker/entrypoint.sh`
- `bash -n ubuntu-kde-docker/setup-wine-container.sh`
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `shellcheck ubuntu-kde-docker/entrypoint.sh ubuntu-kde-docker/setup-wine-container.sh` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_b_688dd82fad20832f877cd34a70275b7c