### PR TITLE
fix: default user context in marketing optimization script

### DIFF
--- a/ubuntu-kde-docker/setup-marketing-optimization.sh
+++ b/ubuntu-kde-docker/setup-marketing-optimization.sh
@@ -37,6 +37,11 @@ cat > "/opt/marketing-optimization/performance/graphics-optimization.sh" << 'EOF
 #!/bin/bash
 set -euo pipefail
 
+# Ensure development user context is available when executed independently
+DEV_USERNAME="${DEV_USERNAME:-devuser}"
+DEV_HOME="/home/${DEV_USERNAME}"
+export DEV_USERNAME DEV_HOME
+
 log_info() {
     echo "$(date '+%Y-%m-%d %H:%M:%S') [MARKETING-OPT] $*"
 }


### PR DESCRIPTION
## Summary
- ensure marketing graphics optimization script sets default dev user context

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_b_688de12f16c0832f8e1a295f93527a6d