### PR TITLE
Fix: Resolve container startup failures

### DIFF
--- a/ubuntu-kde-docker/Dockerfile
+++ b/ubuntu-kde-docker/Dockerfile
@@ -163,6 +163,8 @@ COPY setup-advanced-features.sh /usr/local/bin/setup-advanced-features.sh
 COPY setup-marketing-optimization.sh /usr/local/bin/setup-marketing-optimization.sh
 COPY setup-modern-features.sh /usr/local/bin/setup-modern-features.sh
 COPY setup-ttyd.sh /usr/local/bin/setup-ttyd.sh
+COPY start-dbus-first.sh /usr/local/bin/start-dbus-first.sh
+COPY start-vnc-robust.sh /usr/local/bin/start-vnc-robust.sh
 COPY service-health.sh /usr/local/bin/service-health.sh
 COPY test-desktop-audio.sh /usr/local/bin/test-desktop-audio.sh
 COPY audio-validation.sh /usr/local/bin/audio-validation.sh
@@ -172,6 +174,8 @@ COPY health-check.sh /usr/local/bin/health-check.sh
 COPY fix-permissions.sh /usr/local/bin/fix-permissions.sh
 COPY test-polkit.sh /usr/local/bin/test-polkit.sh
 RUN chmod +x /usr/local/bin/setup-*.sh \
+    /usr/local/bin/start-dbus-first.sh \
+    /usr/local/bin/start-vnc-robust.sh \
     /usr/local/bin/service-health.sh \
     /usr/local/bin/test-desktop-audio.sh \
     /usr/local/bin/audio-monitor.sh \

--- a/ubuntu-kde-docker/start-dbus-first.sh
+++ b/ubuntu-kde-docker/start-dbus-first.sh
@@ -1,0 +1,61 @@
+#!/bin/bash
+set -e
+
+echo "INFO: Robust D-Bus starter script initiated."
+
+# 1. Ensure directories exist and have correct permissions
+mkdir -p /run/dbus
+chown messagebus:messagebus /run/dbus
+chmod 755 /run/dbus
+
+# 2. Clean up stale files from a previous run
+rm -f /run/dbus/system_bus_socket
+rm -f /run/dbus/pid
+
+echo "INFO: Starting system D-Bus daemon."
+# 3. Start the system D-Bus daemon. We will keep it in the foreground for supervisor.
+# The script will wait for it at the end.
+/usr/bin/dbus-daemon --system --nofork --nosyslog &
+DBUS_PID=$!
+
+
+# 4. Wait for the D-Bus socket to be created
+echo "INFO: Waiting for D-Bus socket to be created..."
+counter=0
+while [ ! -S /run/dbus/system_bus_socket ] && [ $counter -lt 20 ]; do
+  sleep 0.5
+  counter=$((counter+1))
+done
+
+if [ ! -S /run/dbus/system_bus_socket ]; then
+  echo "ERROR: D-Bus socket was not created in time. Exiting."
+  kill $DBUS_PID
+  exit 1
+fi
+echo "INFO: D-Bus socket is up."
+
+# 5. Start accounts-daemon
+echo "INFO: Starting accounts-daemon."
+# Path from startup log
+if [ -x /usr/libexec/accounts-daemon ]; then
+    /usr/libexec/accounts-daemon &
+# Other common path
+elif [ -x /usr/lib/accountsservice/accounts-daemon ]; then
+    /usr/lib/accountsservice/accounts-daemon &
+else
+    echo "WARNING: accounts-daemon not found."
+fi
+
+# 6. Start polkitd
+echo "INFO: Starting polkitd."
+# Common path for polkitd
+if [ -x /usr/lib/polkit-1/polkitd ]; then
+    /usr/lib/polkit-1/polkitd --no-debug &
+else
+    echo "WARNING: polkitd not found."
+fi
+
+echo "INFO: D-Bus and related services startup sequence complete."
+
+# Wait for the main dbus-daemon process. If it dies, this script will exit and supervisor will restart it.
+wait $DBUS_PID

--- a/ubuntu-kde-docker/start-vnc-robust.sh
+++ b/ubuntu-kde-docker/start-vnc-robust.sh
@@ -1,0 +1,33 @@
+#!/bin/bash
+set -e
+
+echo "INFO: Robust VNC starter script initiated."
+
+# 1. Wait for the D-Bus socket to be created
+echo "INFO: Waiting for D-Bus socket before starting VNC..."
+counter=0
+while [ ! -S /run/dbus/system_bus_socket ] && [ $counter -lt 30 ]; do
+  sleep 1
+  counter=$((counter+1))
+done
+
+if [ ! -S /run/dbus/system_bus_socket ]; then
+  echo "ERROR: D-Bus socket not available. VNC will not start."
+  exit 1
+fi
+echo "INFO: D-Bus is ready."
+
+# 2. Ensure .Xauthority file exists
+# The vncserver script should handle this, but as a fallback, we can touch it.
+# The log showed "xauth: file /root/.Xauthority does not exist"
+# The VNC server is run as root according to supervisord.conf
+if [ ! -f /root/.Xauthority ]; then
+    echo "INFO: .Xauthority file not found. Creating it."
+    touch /root/.Xauthority
+fi
+
+echo "INFO: Starting KasmVNC server."
+# 3. Start the VNC server.
+# The original command was `vncserver :1`. We will execute that here.
+# We use exec to replace the shell process with the vncserver process.
+exec /usr/bin/vncserver :1

--- a/ubuntu-kde-docker/supervisord.conf
+++ b/ubuntu-kde-docker/supervisord.conf
@@ -6,13 +6,13 @@ minfds=1024
 minprocs=200
 
 [program:dbus]
-command=/bin/sh -c "mkdir -p /run/dbus; /usr/bin/dbus-daemon --system --nofork --nosyslog"
-priority=15
+command=/usr/local/bin/start-dbus-first.sh
+priority=10
 autostart=true
 autorestart=true
 user=root
 startsecs=5
-startretries=5
+startretries=10
 stdout_logfile=/var/log/supervisor/dbus.log
 stderr_logfile=/var/log/supervisor/dbus.log
 
@@ -29,7 +29,7 @@ stdout_logfile=/var/log/supervisor/pulseaudio.log
 stderr_logfile=/var/log/supervisor/pulseaudio.log
 
 [program:KasmVNC]
-command=/usr/bin/vncserver :1
+command=/usr/local/bin/start-vnc-robust.sh
 priority=35
 autostart=true
 autorestart=true


### PR DESCRIPTION
This commit addresses a cascade of service failures within the Docker container that prevented the KDE desktop, KasmVNC, and other services from starting.

The root cause was identified as an unstable startup sequence for the D-Bus system daemon. This led to failures in services that depend on D-Bus, including PolicyKit, KasmVNC, and the KDE Plasma desktop itself.

The following changes have been made to resolve these issues:

1.  **Robust D-Bus Startup:** A new script, `start-dbus-first.sh`, has been created to manage the startup of `dbus-daemon`, `accounts-daemon`, and `polkitd`. This script ensures that D-Bus is fully initialized before other services are launched.

2.  **Reliable VNC Startup:** A new wrapper script, `start-vnc-robust.sh`, has been created for KasmVNC. This script waits for the D-Bus service to be active and ensures that X11 authentication files are present before starting the VNC server.

3.  **Updated Supervisor Configuration:** `supervisord.conf` has been modified to use these new, more reliable startup scripts. The startup priority of the D-Bus service has been increased to enforce a correct startup order.

4.  **Dockerfile Update:** The new scripts have been added to the `Dockerfile` and made executable.

These changes are intended to create a more stable and predictable startup process for the container, resolving the reported errors and ensuring that all services become available as expected.