### PR TITLE
I've fixed an issue in your `entrypoint.sh` script.

### DIFF
--- a/ubuntu-kde-docker/entrypoint.sh
+++ b/ubuntu-kde-docker/entrypoint.sh
@@ -218,3 +218,4 @@ PrintMotd no
 TCPKeepAlive yes
 UsePrivilegeSeparation sandbox
 PidFile /run/sshd.pid
+EOF


### PR DESCRIPTION
The script was failing due to a syntax error. A here-document initiated with `cat > /etc/ssh/sshd_config << 'EOF'` was missing its `EOF` terminator, which was causing the script to exit prematurely and the container to enter a restart loop.

I've added the missing `EOF` line to the end of the script. This resolves the error and should allow the container to start up correctly.