### PR TITLE
Define dev user env vars for supervisord

### DIFF
--- a/ubuntu-kde-docker/Dockerfile
+++ b/ubuntu-kde-docker/Dockerfile
@@ -139,6 +139,9 @@ ENV LANGUAGE=en_US.UTF-8
 ENV LC_ALL=en_US.UTF-8
 ENV TTYD_USER=terminal
 ENV TTYD_PASSWORD=terminal
+ENV DEV_USERNAME=devuser
+ENV DEV_UID=1000
+ENV DEV_GID=1000
 # Create directories and VNC setup for KasmVNC
 RUN mkdir -p /var/run/sshd /root/.vnc /tmp/.X11-unix && \
     chmod 1777 /tmp/.X11-unix

--- a/ubuntu-kde-docker/entrypoint.sh
+++ b/ubuntu-kde-docker/entrypoint.sh
@@ -15,6 +15,11 @@ echo "🚀 Starting Ubuntu KDE Marketing Agency WebTop..."
 : "${TTYD_PASSWORD:=TerminalPassw0rd!}"
 : "${ENABLE_GOOGLE_ADS_EDITOR:=false}"
 
+# Export variables so they are available to child processes like supervisord
+export DEV_USERNAME DEV_PASSWORD DEV_UID DEV_GID \
+       ADMIN_USERNAME ADMIN_PASSWORD ROOT_PASSWORD \
+       TTYD_USER TTYD_PASSWORD ENABLE_GOOGLE_ADS_EDITOR
+
 # Logging function
 log_info() {
     echo "$(date '+%Y-%m-%d %H:%M:%S') [INFO] $*"
@@ -219,3 +224,6 @@ TCPKeepAlive yes
 UsePrivilegeSeparation sandbox
 PidFile /run/sshd.pid
 EOF
+
+# Launch the main process (e.g., supervisord) passed as arguments
+exec "$@"

--- a/ubuntu-kde-docker/supervisord.conf
+++ b/ubuntu-kde-docker/supervisord.conf
@@ -58,7 +58,7 @@ autostart=true
 autorestart=true
 stopsignal=TERM
 user=root
-environment=TTYD_USER=%(ENV_DEV_USER)s,TTYD_PASSWORD=%(ENV_TTYD_PASSWORD)s,TTYD_PORT=7681
+environment=TTYD_USER=%(ENV_DEV_USERNAME)s,TTYD_PASSWORD=%(ENV_TTYD_PASSWORD)s,TTYD_PORT=7681
 startsecs=10
 startretries=5
 exitcodes=0,130


### PR DESCRIPTION
## Summary
- export dev user and auth variables to child processes
- ensure entrypoint runs supervisord after initialization
- provide default DEV_* environment variables for supervisor

## Testing
- `npm test` (fails: Missing script "test")
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_b_688e052b8ca8832fb0a16e7d7cdd11cc