### PR TITLE
Define default KasmVNC port variables

### DIFF
--- a/ubuntu-kde-docker/Dockerfile
+++ b/ubuntu-kde-docker/Dockerfile
@@ -142,6 +142,8 @@ ENV TTYD_PASSWORD=terminal
 ENV DEV_USERNAME=devuser
 ENV DEV_UID=1000
 ENV DEV_GID=1000
+ENV ENV_KASMVNC_PORT=6901
+ENV ENV_KASMVNC_VNC_PORT=5901
 # Create directories and VNC setup for KasmVNC
 RUN mkdir -p /var/run/sshd /root/.vnc /tmp/.X11-unix && \
     chmod 1777 /tmp/.X11-unix

--- a/ubuntu-kde-docker/docker-compose.dev.yml
+++ b/ubuntu-kde-docker/docker-compose.dev.yml
@@ -24,6 +24,9 @@ services:
       - "8090:8090"     # Collaboration Hub
     env_file:
       - .env
+    environment:
+      - ENV_KASMVNC_PORT=6901
+      - ENV_KASMVNC_VNC_PORT=5901
     volumes:
       - ./dev_config:/config
       - ./logs:/var/log/supervisor

--- a/ubuntu-kde-docker/docker-compose.prod.yml
+++ b/ubuntu-kde-docker/docker-compose.prod.yml
@@ -22,6 +22,9 @@ services:
       - "8090:8090"   # Collaboration Hub
     env_file:
       - .env.production
+    environment:
+      - ENV_KASMVNC_PORT=6901
+      - ENV_KASMVNC_VNC_PORT=5901
     volumes:
       - production_config:/config
       - production_logs:/var/log/supervisor

--- a/ubuntu-kde-docker/docker-compose.yml
+++ b/ubuntu-kde-docker/docker-compose.yml
@@ -32,6 +32,8 @@ services:
       - DISPLAY=:1
       - XDG_RUNTIME_DIR=/run/user/1000
       - DBUS_SESSION_BUS_ADDRESS=unix:path=/run/user/1000/bus
+      - ENV_KASMVNC_PORT=6901
+      - ENV_KASMVNC_VNC_PORT=5901
     volumes:
       - ${DATA_ROOT}/default/config:/config
       - ${DATA_ROOT}/default/logs:/var/log/supervisor


### PR DESCRIPTION
## Summary
- set `ENV_KASMVNC_PORT` and `ENV_KASMVNC_VNC_PORT` defaults in Dockerfile
- expose KasmVNC port settings in dev/prod/standard docker-compose files

## Testing
- `npm install`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_b_688e0ef538c0832f9e5d8c2fd58ae0b1