### PR TITLE
Refine docker-compose ports

### DIFF
--- a/ubuntu-kde-docker/docker-compose.dev.yml
+++ b/ubuntu-kde-docker/docker-compose.dev.yml
@@ -13,15 +13,7 @@ services:
       - "7681:7681"     # ttyd terminal
       - "8080:8080"     # Audio Bridge
       - "4713:4713"     # PulseAudio
-      - "8082:8082"     # Enhanced Clipboard
-      - "8083:8083"     # File Transfer
-      - "8084:8084"     # Monitor API
-      - "8085:8085"     # Recording API
-      - "8086:8086"     # Performance Profiles
-      - "8087:8087"     # Workflow Automation
-      - "8088:8088"     # Cloud Integration
-      - "8089:8089"     # AI Assistant
-      - "8090:8090"     # Collaboration Hub
+      - "5555:5555"     # ADB for Android
     env_file:
       - .env
     environment:

--- a/ubuntu-kde-docker/docker-compose.prod.yml
+++ b/ubuntu-kde-docker/docker-compose.prod.yml
@@ -9,17 +9,10 @@ services:
       - "80:80"       # KasmVNC (behind reverse proxy)
       - "443:443"     # HTTPS (behind reverse proxy)
       - "2222:22"     # SSH
+      - "7681:7681"   # ttyd terminal
       - "8080:8080"   # Audio Bridge
       - "4713:4713"   # PulseAudio
-      - "8082:8082"   # Enhanced Clipboard
-      - "8083:8083"   # File Transfer
-      - "8084:8084"   # Monitor API
-      - "8085:8085"   # Recording API
-      - "8086:8086"   # Performance Profiles
-      - "8087:8087"   # Workflow Automation
-      - "8088:8088"   # Cloud Integration
-      - "8089:8089"   # AI Assistant
-      - "8090:8090"   # Collaboration Hub
+      - "5555:5555"   # ADB for Android
     env_file:
       - .env.production
     environment:

--- a/ubuntu-kde-docker/docker-compose.yml
+++ b/ubuntu-kde-docker/docker-compose.yml
@@ -16,15 +16,6 @@ services:
       - "7681:7681"     # ttyd terminal
       - "8080:8080"     # Audio Bridge
       - "4713:4713"     # PulseAudio
-      - "8082:8082"     # Enhanced Clipboard
-      - "8083:8083"     # File Transfer
-      - "8084:8084"     # Monitor API
-      - "8085:8085"     # Recording API
-      - "8086:8086"     # Performance Profiles
-      - "8087:8087"     # Workflow Automation
-      - "8088:8088"     # Cloud Integration
-      - "8089:8089"     # AI Assistant
-      - "8090:8090"     # Collaboration Hub
       - "5555:5555"     # ADB for Android
     env_file:
       - .env


### PR DESCRIPTION
## Summary
- Drop unused feature ports from all docker-compose variants
- Expose ADB 5555 and ttyd 7681 where missing
- Standardize essential port mappings across dev, prod, and default configurations

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_b_688e11ee68e4832fb5933738114336fa