### PR TITLE
Fix KasmVNC env vars for supervisord

### DIFF
--- a/ubuntu-kde-docker/Dockerfile
+++ b/ubuntu-kde-docker/Dockerfile
@@ -142,8 +142,8 @@ ENV TTYD_PASSWORD=terminal
 ENV DEV_USERNAME=devuser
 ENV DEV_UID=1000
 ENV DEV_GID=1000
-ENV ENV_KASMVNC_PORT=80
-ENV ENV_KASMVNC_VNC_PORT=5901
+ENV KASMVNC_PORT=80
+ENV KASMVNC_VNC_PORT=5901
 # Create directories and VNC setup for KasmVNC
 RUN mkdir -p /var/run/sshd /root/.vnc /tmp/.X11-unix && \
     chmod 1777 /tmp/.X11-unix

--- a/ubuntu-kde-docker/docker-compose.dev.yml
+++ b/ubuntu-kde-docker/docker-compose.dev.yml
@@ -18,8 +18,8 @@ services:
     env_file:
       - .env
     environment:
-      - ENV_KASMVNC_PORT=80
-      - ENV_KASMVNC_VNC_PORT=5901
+      - KASMVNC_PORT=80
+      - KASMVNC_VNC_PORT=5901
     volumes:
       - ./dev_config:/config
       - ./logs:/var/log/supervisor

--- a/ubuntu-kde-docker/docker-compose.prod.yml
+++ b/ubuntu-kde-docker/docker-compose.prod.yml
@@ -16,8 +16,8 @@ services:
     env_file:
       - .env.production
     environment:
-      - ENV_KASMVNC_PORT=80
-      - ENV_KASMVNC_VNC_PORT=5901
+      - KASMVNC_PORT=80
+      - KASMVNC_VNC_PORT=5901
     volumes:
       - production_config:/config
       - production_logs:/var/log/supervisor

--- a/ubuntu-kde-docker/docker-compose.yml
+++ b/ubuntu-kde-docker/docker-compose.yml
@@ -24,8 +24,8 @@ services:
       - DISPLAY=:1
       - XDG_RUNTIME_DIR=/run/user/1000
       - DBUS_SESSION_BUS_ADDRESS=unix:path=/run/user/1000/bus
-      - ENV_KASMVNC_PORT=80
-      - ENV_KASMVNC_VNC_PORT=5901
+      - KASMVNC_PORT=80
+      - KASMVNC_VNC_PORT=5901
     volumes:
       - ${DATA_ROOT}/default/config:/config
       - ${DATA_ROOT}/default/logs:/var/log/supervisor


### PR DESCRIPTION
## Summary
- Define `KASMVNC_PORT` and `KASMVNC_VNC_PORT` in Dockerfile so supervisor can expand them
- Update docker-compose files to use the corrected variable names

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_b_688e1e05cf90832fbc0397859ab08ed7