### PR TITLE
Fix supervisor script paths for dbus and VNC

### DIFF
--- a/ubuntu-kde-docker/supervisord.conf
+++ b/ubuntu-kde-docker/supervisord.conf
@@ -6,7 +6,7 @@ minfds=1024
 minprocs=200
 
 [program:dbus]
-command=/app/ubuntu-kde-docker/start-dbus-first.sh
+command=/usr/local/bin/start-dbus-first.sh
 priority=10
 autostart=true
 autorestart=true
@@ -29,7 +29,7 @@ stdout_logfile=/var/log/supervisor/pulseaudio.log
 stderr_logfile=/var/log/supervisor/pulseaudio.log
 
 [program:KasmVNC]
-command=/app/ubuntu-kde-docker/start-vnc-robust.sh
+command=/usr/local/bin/start-vnc-robust.sh
 priority=35
 autostart=true
 autorestart=true


### PR DESCRIPTION
## Summary
- point dbus and VNC supervisor commands to `/usr/local/bin` scripts so services start correctly

## Testing
- `npm test` (fails: Missing script "test")
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_b_688e23d3a0d4832faac7ec5325b41551