### PR TITLE
Install KasmVNC server and fix startup script

### DIFF
--- a/ubuntu-kde-docker/Dockerfile
+++ b/ubuntu-kde-docker/Dockerfile
@@ -187,6 +187,9 @@ RUN chmod +x /usr/local/bin/setup-*.sh \
     /usr/local/bin/test-polkit.sh \
     /usr/local/bin/fix-audio-startup.sh
 
+# Install KasmVNC server
+RUN /usr/local/bin/setup-kasmvnc.sh
+
 # Initialize audio system during build
 RUN /usr/local/bin/setup-audio.sh && \
     /usr/local/bin/fix-audio-startup.sh

--- a/ubuntu-kde-docker/start-vnc-robust.sh
+++ b/ubuntu-kde-docker/start-vnc-robust.sh
@@ -27,7 +27,6 @@ if [ ! -f /root/.Xauthority ]; then
 fi
 
 echo "INFO: Starting KasmVNC server."
-# 3. Start the VNC server.
-# The original command was `vncserver :1`. We will execute that here.
-# We use exec to replace the shell process with the vncserver process.
-exec /usr/bin/vncserver :1
+# 3. Start the VNC server using the KasmVNC binary.
+# We use exec to replace the shell process with the kasmvncserver process.
+exec /usr/bin/kasmvncserver :1


### PR DESCRIPTION
## Summary
- Install KasmVNC during image build via setup-kasmvnc.sh
- Launch KasmVNC with the kasmvncserver binary in startup script

## Testing
- `bash -n ubuntu-kde-docker/start-vnc-robust.sh`
- `npm test` *(fails: Missing script "test")*


------
https://chatgpt.com/codex/tasks/task_b_688e29689570832fa210e20d77864a18