### PR TITLE
refactor: centralize xstartup script

### DIFF
--- a/ubuntu-kde-docker/entrypoint.sh
+++ b/ubuntu-kde-docker/entrypoint.sh
@@ -128,14 +128,8 @@ sed -i 's/^%sudo.*/%sudo ALL=(ALL) NOPASSWD:ALL/' /etc/sudoers
 
 # Prepare VNC startup script for dev user
 mkdir -p "/home/${DEV_USERNAME}/.vnc"
-cat <<'XEOF' > "/home/${DEV_USERNAME}/.vnc/xstartup"
-#!/bin/sh
-export XKL_XMODMAP_DISABLE=1
-export PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
-exec dbus-launch --exit-with-session /usr/bin/startplasma-x11
-XEOF
+install -m 755 /tmp/xstartup "/home/${DEV_USERNAME}/.vnc/xstartup"
 chown -R "${DEV_USERNAME}":"${DEV_USERNAME}" "/home/${DEV_USERNAME}/.vnc"
-chmod +x "/home/${DEV_USERNAME}/.vnc/xstartup"
 
 # XDG runtime directory
 mkdir -p "/run/user/${DEV_UID}"

--- a/ubuntu-kde-docker/start-vnc-robust.sh
+++ b/ubuntu-kde-docker/start-vnc-robust.sh
@@ -74,16 +74,7 @@ export XAUTHORITY=/root/.Xauthority
 mkdir -p /root/.vnc
 if [ ! -f /root/.vnc/xstartup ]; then
     echo "🔧 Creating VNC xstartup script..."
-    cat > /root/.vnc/xstartup << 'EOF'
-#!/bin/sh
-export XKL_XMODMAP_DISABLE=1
-export PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
-export DISPLAY=:1
-unset SESSION_MANAGER
-unset DBUS_SESSION_BUS_ADDRESS
-exec dbus-launch --exit-with-session /usr/bin/startplasma-x11
-EOF
-    chmod +x /root/.vnc/xstartup
+    install -m 755 /tmp/xstartup /root/.vnc/xstartup
 fi
 
 # 6. Start the VNC server

--- a/ubuntu-kde-docker/xstartup
+++ b/ubuntu-kde-docker/xstartup
@@ -1,4 +1,17 @@
 #!/bin/sh
+
+# Disable xmodmap to prevent interfering with keyboard layouts
 export XKL_XMODMAP_DISABLE=1
+
+# Ensure essential binaries are in PATH
 export PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
+
+# Default to VNC display :1 if DISPLAY is unset
+export DISPLAY=${DISPLAY:-:1}
+
+# Prevent conflicts with existing desktop sessions
+unset SESSION_MANAGER
+unset DBUS_SESSION_BUS_ADDRESS
+
+# Launch KDE Plasma within a D-Bus session
 exec dbus-launch --exit-with-session /usr/bin/startplasma-x11


### PR DESCRIPTION
## Summary
- refactor xstartup with DISPLAY handling and session cleanup
- reuse centralized xstartup in entrypoint and VNC startup

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_b_688e4aba688c832fabee5bdcb86db0ff