### PR TITLE
refactor: streamline volume setup

### DIFF
--- a/ubuntu-kde-docker/setup-volumes.sh
+++ b/ubuntu-kde-docker/setup-volumes.sh
@@ -3,36 +3,31 @@ set -euo pipefail
 
 # Volume Setup Script for Enhanced Container Management
 
-BACKUP_DIR="./backups"
-TEMPLATE_DIR="./templates"
-SHARED_DIR="./shared"
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+cd "$SCRIPT_DIR"
+
+BACKUP_DIR="$SCRIPT_DIR/backups"
+TEMPLATE_DIR="$SCRIPT_DIR/templates"
 
 echo "🔧 Setting up enhanced volume management..."
 
-# Create directories
-mkdir -p "$BACKUP_DIR" "$TEMPLATE_DIR" "$SHARED_DIR"
+# Ensure base directories and shared volume exist using webtop initialization
+./webtop.sh volumes list >/dev/null 2>&1 || true
 
-# Create shared resources structure
-mkdir -p "$SHARED_DIR/resources" "$SHARED_DIR/fonts" "$SHARED_DIR/tools"
-
-# Create shared resources volume if it doesn't exist
-if ! docker volume ls | grep -q "shared_resources"; then
-    echo "📦 Creating shared resources volume..."
-    docker volume create shared_resources
-    
-    # Populate shared resources with basic items
-    echo "📁 Setting up shared resources..."
-    docker run --rm -v shared_resources:/shared alpine sh -c "
-        mkdir -p /shared/fonts /shared/tools /shared/resources /shared/templates
-        echo 'Shared resources initialized' > /shared/README.txt
+# Populate shared resources volume if empty
+if ! docker run --rm -v shared_resources:/shared alpine test -f /shared/README.txt >/dev/null 2>&1; then
+    echo "📦 Populating shared resources volume..."
+    docker run --rm -v shared_resources:/shared alpine sh -c "\
+        mkdir -p /shared/fonts /shared/tools /shared/resources /shared/templates\n\
+        echo 'Shared resources initialized' > /shared/README.txt\n\
     "
 fi
 
-# Create basic templates directory structure
-mkdir -p "$TEMPLATE_DIR/basic" "$TEMPLATE_DIR/marketing" "$TEMPLATE_DIR/developer"
-
-# Create template metadata for basic template
-cat > "$TEMPLATE_DIR/basic/template.json" << 'EOF'
+# Create basic template if missing
+if [ ! -f "$TEMPLATE_DIR/basic/template.json" ]; then
+    echo "📝 Creating basic template..."
+    mkdir -p "$TEMPLATE_DIR/basic"
+    cat > "$TEMPLATE_DIR/basic/template.json" <<'TEMPLATE'
 {
     "name": "basic",
     "source_container": "base",
@@ -40,16 +35,16 @@ cat > "$TEMPLATE_DIR/basic/template.json" << 'EOF'
     "description": "Basic KDE desktop environment",
     "volumes": ["config", "home"]
 }
-EOF
+TEMPLATE
+fi
 
 echo "📁 Directory structure:"
 echo "  📦 Backups: $BACKUP_DIR"
-echo "  📝 Templates: $TEMPLATE_DIR" 
-echo "  🔗 Shared: $SHARED_DIR"
+echo "  📝 Templates: $TEMPLATE_DIR"
 echo "  🌐 Shared Volume: shared_resources"
 
 echo "✅ Volume management setup complete!"
-echo ""
+echo
 echo "💡 Usage Examples:"
 echo "  ./webtop.sh up --name client1                    # Create container"
 echo "  ./webtop.sh backup client1                       # Backup container"
@@ -58,4 +53,4 @@ echo "  ./webtop.sh template save client1 my-template    # Save as template"
 echo "  ./webtop.sh template create client3 my-template  # Create from template"
 echo "  ./webtop.sh volumes list                         # List all volumes"
 echo "  ./webtop.sh volumes backup-all                   # Backup all containers"
-echo ""
+echo


### PR DESCRIPTION
## Summary
- streamline setup-volumes script to delegate initialization to webtop.sh
- populate shared resources volume only when empty and conditionally create basic template

## Testing
- `shellcheck ubuntu-kde-docker/setup-volumes.sh`
- `npm test` *(fails: Missing script "test")*
- `npm run lint`
- `docker version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_b_688e4b6a6c3c832f9e94848db6676019