### PR TITLE
refactor: expand supervisor services

### DIFF
--- a/ubuntu-kde-docker/supervisord.conf
+++ b/ubuntu-kde-docker/supervisord.conf
@@ -9,7 +9,7 @@ pidfile=/var/run/supervisord.pid
 
 [program:dbus]
 command=/usr/local/bin/start-dbus-first.sh
-priority=10
+priority=15
 autostart=true
 autorestart=true
 user=root
@@ -30,9 +30,31 @@ startsecs=5
 stdout_logfile=/var/log/supervisor/pulseaudio.log
 stderr_logfile=/var/log/supervisor/pulseaudio.log
 
-[program:KasmVNC]
+[program:audiovalidation]
+command=/usr/local/bin/audio-validation.sh
+priority=28
+autostart=true
+autorestart=false
+user=root
+startsecs=5
+startretries=1
+stdout_logfile=/var/log/supervisor/audio-validation.log
+stderr_logfile=/var/log/supervisor/audio-validation.log
+
+[program:audiomonitor]
+command=/usr/local/bin/audio-monitor.sh monitor
+priority=30
+autostart=true
+autorestart=true
+user=root
+startsecs=10
+startretries=3
+stdout_logfile=/var/log/supervisor/audio-monitor.log
+stderr_logfile=/var/log/supervisor/audio-monitor.log
+
+[program:kasmvnc]
 command=/usr/local/bin/start-vnc-robust.sh
-priority=35
+priority=40
 autostart=true
 autorestart=true
 stopsignal=TERM
@@ -50,7 +72,7 @@ stderr_logfile_backups=3
 
 [program:sshd]
 command=/usr/sbin/sshd -D
-priority=42
+priority=46
 autostart=true
 autorestart=true
 stopsignal=TERM
@@ -60,7 +82,7 @@ stderr_logfile=/var/log/supervisor/sshd.log
 
 [program:ttyd]
 command=/bin/bash /usr/local/bin/ttyd-wrapper.sh
-priority=45
+priority=48
 autostart=true
 autorestart=true
 stopsignal=TERM
@@ -71,3 +93,37 @@ startretries=5
 exitcodes=0,130
 stdout_logfile=/var/log/supervisor/ttyd.log
 stderr_logfile=/var/log/supervisor/ttyd.log
+
+[program:servicehealth]
+command=/usr/local/bin/service-health.sh smart-monitor
+priority=52
+autostart=true
+autorestart=true
+user=root
+startsecs=15
+startretries=3
+stdout_logfile=/var/log/supervisor/service-health.log
+stderr_logfile=/var/log/supervisor/service-health.log
+
+[program:setupdesktop]
+command=/usr/local/bin/setup-desktop.sh
+priority=55
+autostart=true
+autorestart=false
+user=root
+startsecs=10
+startretries=1
+stdout_logfile=/var/log/supervisor/setup-desktop.log
+stderr_logfile=/var/log/supervisor/setup-desktop.log
+
+[program:systemvalidation]
+command=/usr/local/bin/system-validation.sh
+priority=60
+autostart=true
+autorestart=false
+user=root
+startsecs=20
+startretries=1
+stdout_logfile=/var/log/supervisor/system-validation.log
+stderr_logfile=/var/log/supervisor/system-validation.log
+


### PR DESCRIPTION
## Summary
- align service priorities and naming in `supervisord.conf`
- add audio validation/monitoring, service-health, desktop setup, and system validation programs

## Testing
- `npm test` *(fails: Missing script)*
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_b_688e4ef14798832f82874fa7890b459c