### PR TITLE
refactor: improve Google Ads Editor setup

### DIFF
--- a/ubuntu-kde-docker/setup-google-ads-editor.sh
+++ b/ubuntu-kde-docker/setup-google-ads-editor.sh
@@ -3,6 +3,8 @@ set -euo pipefail
 
 DEV_USERNAME="${DEV_USERNAME:-devuser}"
 DEV_HOME="/home/${DEV_USERNAME}"
+APPLICATIONS_DIR="${DEV_HOME}/.local/share/applications"
+DESKTOP_DIR="${DEV_HOME}/Desktop"
 
 echo "📊 Setting up Google Ads Editor..."
 
@@ -13,8 +15,9 @@ if [ ! -d "${DEV_HOME}/.wine" ]; then
 fi
 
 # Set up Google Ads Editor as the dev user
-sudo -u "$DEV_USERNAME" bash << 'ADS_EDITOR_SETUP'
-export WINEPREFIX="/home/devuser/.wine"
+sudo -u "$DEV_USERNAME" bash <<'ADS_EDITOR_SETUP'
+set -euo pipefail
+export WINEPREFIX="$HOME/.wine"
 export WINEARCH="win64"
 export WINEDLLOVERRIDES="mscoree,mshtml="
 export DISPLAY=:1
@@ -44,24 +47,25 @@ ADS_EDITOR_SETUP
 
 # Create desktop shortcut with correct username
 echo "🔗 Creating desktop shortcut..."
-mkdir -p "${DEV_HOME}/Desktop"
+mkdir -p "$APPLICATIONS_DIR" "$DESKTOP_DIR"
 
-cat > "${DEV_HOME}/Desktop/GoogleAdsEditor.desktop" << EOF
+cat > "$APPLICATIONS_DIR/google-ads-editor.desktop" <<EOF
 [Desktop Entry]
 Version=1.0
 Type=Application
 Name=Google Ads Editor
 Comment=Manage your Google Ads campaigns
-Exec=wine "/home/${DEV_USERNAME}/.wine/drive_c/Program Files/Google/Google Ads Editor/google_ads_editor.exe"
+Exec=wine "${DEV_HOME}/.wine/drive_c/Program Files/Google/Google Ads Editor/google_ads_editor.exe"
 Icon=wine
 Categories=Office;
 Terminal=false
 EOF
 
-# Make desktop shortcut executable
-chmod +x "${DEV_HOME}/Desktop/GoogleAdsEditor.desktop"
+# Copy to desktop and make executable
+cp "$APPLICATIONS_DIR/google-ads-editor.desktop" "$DESKTOP_DIR/"
+chmod +x "$DESKTOP_DIR/google-ads-editor.desktop"
 
 # Set ownership
-chown -R "${DEV_USERNAME}:${DEV_USERNAME}" "${DEV_HOME}"
+chown "${DEV_USERNAME}:${DEV_USERNAME}" "$APPLICATIONS_DIR/google-ads-editor.desktop" "$DESKTOP_DIR/google-ads-editor.desktop"
 
 echo "✅ Google Ads Editor setup complete"


### PR DESCRIPTION
## Summary
- add directory variables for applications and desktop
- run installer as dev user using $HOME-based Wine prefix
- create and install desktop entry in .local/share/applications and copy to Desktop

## Testing
- `bash -n ubuntu-kde-docker/setup-google-ads-editor.sh`
- `shellcheck ubuntu-kde-docker/setup-google-ads-editor.sh`


------
https://chatgpt.com/codex/tasks/task_b_688e50573d28832f94a7f0b0f1c7b037