### PR TITLE
refactor flatpak app setup

### DIFF
--- a/ubuntu-kde-docker/setup-flatpak-apps.sh
+++ b/ubuntu-kde-docker/setup-flatpak-apps.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-set -euxo pipefail
+set -euo pipefail
 
 # Ensure flatpak is available
 if ! command -v flatpak >/dev/null 2>&1; then
@@ -13,54 +13,43 @@ flatpak remote-add --if-not-exists flathub \
 
 # Marketing Agency Focused Applications
 apps=(
-    # Core Design & Creative Tools
-    "org.gimp.GIMP"
-    "org.inkscape.Inkscape"
-    "org.kde.krita"
-    "org.blender.Blender"
+    # Core Design & Creative Tools (APT provides GIMP, Inkscape, Krita, Blender)
     "com.adobe.Reader"
-    
-    # Video & Audio Production
-    "org.kdenlive.kdenlive"
-    "org.openshot.OpenShot"
-    "org.shotcut.Shotcut"
-    "org.audacityteam.Audacity"
-    "com.obsproject.Studio"
-    
+
     # Communication & Collaboration
     "com.slack.Slack"
     "com.discordapp.Discord"
     "us.zoom.Zoom"
     "com.microsoft.Teams"
-    
+
     # Project Management & Productivity
     "com.notion.Notion"
     "com.toggl.TogglDesktop"
     "org.gnome.gitlab.somas.Apostrophe"
-    
+
     # Development & API Tools
     "io.gitkraken.GitKraken"
     "com.getpostman.Postman"
     "org.onlyoffice.desktopeditors"
     "com.wps.Office"
-    
+
     # Browsers for Testing
     "org.chromium.Chromium"
     "org.mozilla.firefox"
-    "com.brave.Browser"
-    
-    # Security & Privacy
+
+    # Security & Privacy (Signal installed via APT)
     "com.bitwarden.desktop"
-    "org.signal.Signal"
-    
-    # File Management & Cloud
+
+    # File Management & Cloud (Nextcloud installed via APT)
     "com.dropbox.Client"
-    "com.nextcloud.desktopclient.nextcloud"
-    
+
     # Email & Communication
     "com.bluemail.BlueMail"
     "org.mozilla.Thunderbird"
-    
+
+    # Media & Streaming
+    "com.spotify.Client"
+
     # Legacy Applications (if needed)
     "com.blackmagicdesign.resolve"
     "com.mysql.Workbench"
@@ -68,10 +57,8 @@ apps=(
 )
 
 for app in "${apps[@]}"; do
-    if ! flatpak info "$app" > /dev/null 2>&1; then
-        flatpak install -y --noninteractive --or-update flathub "$app" || true
-    fi
+    flatpak install -y --noninteractive --or-update flathub "$app" || true
 done
 
 # Update any already installed Flatpak apps
-flatpak update -y || true
+flatpak update -y --noninteractive || true


### PR DESCRIPTION
## Summary
- streamline flatpak app list and remove packages already provided by APT
- add Spotify and clarify categories
- simplify install loop and run noninteractive updates

## Testing
- `bash -n ubuntu-kde-docker/setup-flatpak-apps.sh`
- `shellcheck ubuntu-kde-docker/setup-flatpak-apps.sh`
- `npm test` *(fails: Missing script: "test")*
- `npm run lint` *(fails: Cannot find package '@eslint/js')*


------
https://chatgpt.com/codex/tasks/task_b_688e50900224832f9c7aadfa0b80c9de