### PR TITLE
fix: correct PolicyKit D-Bus configuration

### DIFF
--- a/ubuntu-kde-docker/Dockerfile
+++ b/ubuntu-kde-docker/Dockerfile
@@ -239,14 +239,14 @@ RUN apt-get update && apt-get install -y --no-install-recommends accountsservice
 # Copy PolicyKit configurations to address Ubuntu 24.04 issues
 COPY polkit-localauthority.conf /etc/polkit-1/localauthority.conf.d/50-localauthority.conf
 COPY 50-localauthority.conf /etc/polkit-1/localauthority.conf.d/51-localauthority.conf  
-COPY polkit-dbus.conf /usr/share/dbus-1/system-services/org.freedesktop.PolicyKit1.conf
+COPY polkit-dbus.conf /etc/dbus-1/system.d/org.freedesktop.PolicyKit1.conf
 COPY org.freedesktop.PolicyKit1.service /usr/share/dbus-1/system-services/org.freedesktop.PolicyKit1.service
 COPY devuser-all.rules /etc/polkit-1/rules.d/49-nopasswd_global.rules
 COPY 10-vendor.d-admin.rules /etc/polkit-1/rules.d/10-vendor.d-admin.rules
 
 # Create missing system directories and disable PolicyKit for container environment
 RUN mkdir -p /etc/polkit-1/localauthority.conf.d /etc/polkit-1/rules.d /var/lib/polkit-1 \
-    /var/log/supervisor /run/user/1000 && \
+    /etc/dbus-1/system.d /var/log/supervisor /run/user/1000 && \
     chown -R polkitd:polkitd /var/lib/polkit-1 && \
     chown 1000:1000 /run/user/1000 && \
     chmod 700 /run/user/1000 && \

--- a/ubuntu-kde-docker/entrypoint.sh
+++ b/ubuntu-kde-docker/entrypoint.sh
@@ -77,9 +77,7 @@ if command -v setcap >/dev/null 2>&1; then
 fi
 chmod 4755 /usr/lib/policykit-1/polkit-agent-helper-1 2>/dev/null || true
 
-# Create missing PolicyKit config files for Ubuntu 24.04 bug fix
-cp -f /tmp/polkit-localauthority.conf /etc/polkit-1/localauthority.conf.d/51-ubuntu-admin.conf 2>/dev/null || true
-cp -f /tmp/polkit-dbus.conf /etc/dbus-1/system.d/org.freedesktop.PolicyKit1.conf 2>/dev/null || true
+# PolicyKit configuration installed at build time
 
 # Fix PolicyKit permissions
 chown polkitd:polkitd /var/lib/polkit-1/localauthority 2>/dev/null || true

--- a/ubuntu-kde-docker/polkit-dbus.conf
+++ b/ubuntu-kde-docker/polkit-dbus.conf
@@ -1,13 +1,18 @@
+<?xml version="1.0" encoding="UTF-8"?> <!-- -*- XML -*- -->
+
 <!DOCTYPE busconfig PUBLIC
  "-//freedesktop//DTD D-BUS Bus Configuration 1.0//EN"
  "http://www.freedesktop.org/standards/dbus/1.0/busconfig.dtd">
 <busconfig>
+  <!-- Allow the polkitd daemon to own its well-known name and talk to itself -->
   <policy user="polkitd">
     <allow own="org.freedesktop.PolicyKit1"/>
     <allow send_destination="org.freedesktop.PolicyKit1"/>
     <allow send_interface="org.freedesktop.PolicyKit1.Authority"/>
+    <allow send_interface="org.freedesktop.PolicyKit1.AuthenticationAgent"/>
   </policy>
-  
+
+  <!-- Allow all clients to communicate with polkitd -->
   <policy context="default">
     <allow send_destination="org.freedesktop.PolicyKit1"/>
     <allow send_interface="org.freedesktop.PolicyKit1.Authority"/>


### PR DESCRIPTION
## Summary
- refine polkit D-Bus config and include missing AuthenticationAgent interface
- install PolicyKit D-Bus config into /etc/dbus-1/system.d and ensure directory
- remove unused runtime copy of PolicyKit config

## Testing
- `bash ubuntu-kde-docker/test-polkit.sh`
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_b_688e56d1bdb4832f8bf762f401375735