### PR TITLE
fix: improve jq installation script

### DIFF
--- a/ubuntu-kde-docker/install-jq.sh
+++ b/ubuntu-kde-docker/install-jq.sh
@@ -1,32 +1,38 @@
 #!/bin/bash
+set -euo pipefail
 
 # Install jq for JSON parsing if not available
-if ! command -v jq &> /dev/null; then
+if ! command -v jq >/dev/null 2>&1; then
     echo "Installing jq for JSON parsing..."
-    
-    if command -v apt-get &> /dev/null; then
+
+    if command -v apt-get >/dev/null 2>&1; then
         # Remove broken PostgreSQL repository first
         sudo rm -f /etc/apt/sources.list.d/pgdg.list* 2>/dev/null || true
-        sudo apt-get update -qq && sudo apt-get install -y jq 2>/dev/null
-    elif command -v yum &> /dev/null; then
-        sudo yum install -y jq 2>/dev/null
-    elif command -v brew &> /dev/null; then
-        brew install jq 2>/dev/null
-    elif command -v pacman &> /dev/null; then
-        sudo pacman -S --noconfirm jq 2>/dev/null
+        sudo apt-get update -qq
+        sudo apt-get install -y jq
+    elif command -v dnf >/dev/null 2>&1; then
+        sudo dnf install -y jq
+    elif command -v yum >/dev/null 2>&1; then
+        sudo yum install -y jq
+    elif command -v brew >/dev/null 2>&1; then
+        brew install jq
+    elif command -v pacman >/dev/null 2>&1; then
+        sudo pacman -S --noconfirm jq
     else
         echo "Please install jq manually for your system"
         echo "Ubuntu/Debian: sudo apt-get install jq"
+        echo "Fedora: sudo dnf install jq"
         echo "CentOS/RHEL: sudo yum install jq"
         echo "macOS: brew install jq"
         echo "Arch: sudo pacman -S jq"
         exit 1
     fi
-    
-    if command -v jq &> /dev/null; then
+
+    if command -v jq >/dev/null 2>&1; then
         echo "jq installed successfully"
     else
         echo "Failed to install jq"
         exit 1
     fi
 fi
+


### PR DESCRIPTION
## Summary
- harden jq install helper and support additional package managers

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm ci`
- `npm run lint`
- `bash -n ubuntu-kde-docker/install-jq.sh`


------
https://chatgpt.com/codex/tasks/task_b_688e57ab00b8832f94076e6e35d59dca