### PR TITLE
Align polkit dbus configuration with upstream settings

### DIFF
--- a/ubuntu-kde-docker/polkit-dbus.conf
+++ b/ubuntu-kde-docker/polkit-dbus.conf
@@ -1,15 +1,20 @@
+<?xml version="1.0" encoding="UTF-8"?> <!-- -*- XML -*- -->
+
 <!DOCTYPE busconfig PUBLIC
  "-//freedesktop//DTD D-BUS Bus Configuration 1.0//EN"
  "http://www.freedesktop.org/standards/dbus/1.0/busconfig.dtd">
 <busconfig>
   <policy user="polkitd">
     <allow own="org.freedesktop.PolicyKit1"/>
-    <allow send_destination="org.freedesktop.PolicyKit1"/>
-    <allow send_interface="org.freedesktop.PolicyKit1.Authority"/>
   </policy>
-  
+
   <policy context="default">
     <allow send_destination="org.freedesktop.PolicyKit1"/>
-    <allow send_interface="org.freedesktop.PolicyKit1.Authority"/>
+  </policy>
+
+  <!-- Allow polkitd to send messages on the org.freedesktop.PolicyKit1.AuthenticationAgent interface -->
+  <policy user="polkitd">
+    <allow send_interface="org.freedesktop.PolicyKit1.AuthenticationAgent"/>
   </policy>
 </busconfig>
+


### PR DESCRIPTION
## Summary
- sync polkit DBus config with upstream, removing redundant rules and adding AuthenticationAgent policy

## Testing
- `npm test` (fails: Missing script "test")
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_b_688e5bb2db8c832f98e892ce7d0d67e3