### PR TITLE
refactor: improve permission fix script

### DIFF
--- a/ubuntu-kde-docker/fix-permissions.sh
+++ b/ubuntu-kde-docker/fix-permissions.sh
@@ -4,6 +4,8 @@ set -euo pipefail
 DEV_USERNAME="${DEV_USERNAME:-devuser}"
 DEV_UID="${DEV_UID:-1000}"
 DEV_GID="${DEV_GID:-1000}"
+DEV_HOME="/home/${DEV_USERNAME}"
+readonly DEV_USERNAME DEV_UID DEV_GID DEV_HOME
 
 echo "🔧 Fixing file permissions and ownership..."
 
@@ -14,27 +16,35 @@ if ! id "$DEV_USERNAME" >/dev/null 2>&1; then
 fi
 
 # Fix home directory ownership
-chown -R "${DEV_USERNAME}:${DEV_USERNAME}" "/home/${DEV_USERNAME}" 2>/dev/null || true
+chown -R "${DEV_UID}:${DEV_GID}" "$DEV_HOME" 2>/dev/null || true
 
 # Fix desktop and application directories
-for dir in Desktop .local .config .vnc; do
-    if [ -d "/home/${DEV_USERNAME}/$dir" ]; then
-        chown -R "${DEV_USERNAME}:${DEV_USERNAME}" "/home/${DEV_USERNAME}/$dir"
-        chmod -R u+rwX "/home/${DEV_USERNAME}/$dir"
+dirs=(Desktop Documents Downloads Pictures Videos Music Public Templates .local .config .vnc)
+for dir in "${dirs[@]}"; do
+    path="${DEV_HOME}/${dir}"
+    if [ -d "$path" ]; then
+        chown -R "${DEV_UID}:${DEV_GID}" "$path"
+        chmod -R u+rwX "$path"
     fi
 done
 
 # Fix desktop files permissions
-find "/home/${DEV_USERNAME}/Desktop" -name "*.desktop" -exec chmod +x {} \; 2>/dev/null || true
+desktop_dir="${DEV_HOME}/Desktop"
+if [ -d "$desktop_dir" ]; then
+    find "$desktop_dir" -type f -name "*.desktop" -exec chmod +x {} + 2>/dev/null || true
+fi
 
 # Fix XDG runtime directory
-if [ -d "/run/user/${DEV_UID}" ]; then
-    chown "${DEV_USERNAME}:${DEV_USERNAME}" "/run/user/${DEV_UID}"
-    chmod 700 "/run/user/${DEV_UID}"
+xdg_dir="/run/user/${DEV_UID}"
+if [ -d "$xdg_dir" ]; then
+    chown "${DEV_UID}:${DEV_GID}" "$xdg_dir"
+    chmod 700 "$xdg_dir"
 fi
 
 # Fix supervisor log directory permissions
-mkdir -p /var/log/supervisor
-chmod 755 /var/log/supervisor
+log_dir="/var/log/supervisor"
+mkdir -p "$log_dir"
+chmod 755 "$log_dir"
 
 echo "✅ Permissions fixed successfully"
+


### PR DESCRIPTION
## Summary
- make permission fixer use numeric IDs and common home path
- ensure standard user folders and .desktop files get corrected
- harden XDG runtime and supervisor log directory handling

## Testing
- `bash -n ubuntu-kde-docker/fix-permissions.sh`
- `shellcheck ubuntu-kde-docker/fix-permissions.sh`
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `DEV_USERNAME=root DEV_UID=0 DEV_GID=0 bash ubuntu-kde-docker/fix-permissions.sh`


------
https://chatgpt.com/codex/tasks/task_b_688e5bea3904832fbe9b03a626a25d8a