### PR TITLE
Refine audio startup fix script

### DIFF
--- a/ubuntu-kde-docker/fix-audio-startup.sh
+++ b/ubuntu-kde-docker/fix-audio-startup.sh
@@ -11,6 +11,7 @@ echo "🔧 Fixing audio system startup configuration..."
 
 # Check if we're running during build (user doesn't exist yet) or runtime
 if id "$DEV_USERNAME" >/dev/null 2>&1; then
+    DEV_UID="$(id -u "$DEV_USERNAME")"
     IS_RUNTIME=true
     echo "🔧 Runtime mode: Setting user-specific permissions"
 else
@@ -18,18 +19,12 @@ else
     echo "🔧 Build mode: Skipping user-specific operations"
 fi
 
-# Ensure runtime directories exist (build-safe)
-mkdir -p "/run/user/${DEV_UID}"
-mkdir -p "/run/user/${DEV_UID}/pulse"
+# Ensure runtime directory structure exists (build-safe)
+mkdir -p "/run/user/${DEV_UID}"/{pulse,systemd}
+
 if [ "$IS_RUNTIME" = true ]; then
     chown -R "${DEV_USERNAME}:${DEV_USERNAME}" "/run/user/${DEV_UID}"
     chmod 700 "/run/user/${DEV_UID}"
-fi
-
-# Create systemd-style runtime directory structure
-mkdir -p "/run/user/${DEV_UID}/systemd"
-if [ "$IS_RUNTIME" = true ]; then
-    chown "${DEV_USERNAME}:${DEV_USERNAME}" "/run/user/${DEV_UID}/systemd"
 
     # Ensure PulseAudio config directory exists
     mkdir -p "/home/${DEV_USERNAME}/.config/pulse"
@@ -72,8 +67,9 @@ pcm.fallback {
 }
 EOF
 
-    chown "${DEV_USERNAME}:${DEV_USERNAME}" "/home/${DEV_USERNAME}/.asoundrc"
-    chown "${DEV_USERNAME}:${DEV_USERNAME}" "/home/${DEV_USERNAME}/.config/pulse/client.conf"
+    chown "${DEV_USERNAME}:${DEV_USERNAME}" \
+        "/home/${DEV_USERNAME}/.asoundrc" \
+        "/home/${DEV_USERNAME}/.config/pulse/client.conf"
 fi
 
 # Set proper permissions for audio devices if they exist (runtime only)


### PR DESCRIPTION
## Summary
- ensure runtime UID detection and consolidate audio runtime directories
- simplify ownership updates for PulseAudio and ALSA configs

## Testing
- `shellcheck ubuntu-kde-docker/fix-audio-startup.sh`
- `bash ubuntu-kde-docker/fix-audio-startup.sh`


------
https://chatgpt.com/codex/tasks/task_b_688e5bf89b90832f9c073d05b46dac3c