### PR TITLE
chore: refine prod compose

### DIFF
--- a/ubuntu-kde-docker/docker-compose.prod.yml
+++ b/ubuntu-kde-docker/docker-compose.prod.yml
@@ -1,9 +1,12 @@
+version: "3.9"
+
 services:
   webtop:
     image: ghcr.io/your-org/webtop-kde-marketing:latest
     container_name: webtop-kde-prod
     restart: unless-stopped
     privileged: true
+    init: true
     shm_size: "8gb"
     ports:
       - "32768:80"    # KasmVNC
@@ -30,8 +33,10 @@ services:
       - /run/lock
     cap_add:
       - SYS_ADMIN
+      - NET_ADMIN
     security_opt:
       - seccomp:unconfined
+      - apparmor:unconfined
     deploy:
       resources:
         limits:
@@ -84,6 +89,8 @@ services:
     image: grafana/grafana
     container_name: webtop-grafana
     restart: unless-stopped
+    depends_on:
+      - prometheus
     ports:
       - "3000:3000"
     environment:


### PR DESCRIPTION
## Summary
- specify compose file version and enable init for webtop
- loosen sandboxing and add NET_ADMIN capability
- ensure grafana waits for prometheus before starting

## Testing
- `docker-compose -f ubuntu-kde-docker/docker-compose.prod.yml config`
- `npm test` *(fails: Missing script: "test")*
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_b_688e5c360c7c832f9ec7fada29b04c23