### PR TITLE
refactor: enhance dev docker-compose config

### DIFF
--- a/ubuntu-kde-docker/docker-compose.dev.yml
+++ b/ubuntu-kde-docker/docker-compose.dev.yml
@@ -1,12 +1,15 @@
+version: "3.8"
+
 services:
   webtop:
-    build: 
+    build:
       context: .
       target: development
     container_name: webtop-kde-dev
     restart: unless-stopped
     privileged: true
     shm_size: "4gb"
+    init: true
     ports:
       - "32768:80"      # KasmVNC
       - "5901:5901"     # VNC
@@ -18,23 +21,47 @@ services:
     env_file:
       - .env
     environment:
+      - DISPLAY=:1
+      - XDG_RUNTIME_DIR=/run/user/1000
+      - DBUS_SESSION_BUS_ADDRESS=unix:path=/run/user/1000/bus
       - KASMVNC_PORT=80
       - KASMVNC_VNC_PORT=5901
     volumes:
       - ./dev_config:/config
       - ./logs:/var/log/supervisor
-      - /tmp/.X11-unix:/tmp/.X11-unix:ro
+      - /tmp/.X11-unix:/tmp/.X11-unix:rw
+      - /lib/modules:/lib/modules:ro
+      - /dev:/dev:rw
+      - ./dbus_session:/run/user/1000
+      - ./wine_data:/home/devuser/.wine
+      - ./android_data:/data/android
     devices:
       - /dev/snd:/dev/snd
+      - /dev/kvm:/dev/kvm
+      - /dev/net/tun:/dev/net/tun
     tmpfs:
-      - /tmp
-      - /run
-      - /run/lock
+      - /tmp:exec,size=2g
+      - /run:exec,size=1g
+      - /run/lock:size=100m
     cap_add:
       - SYS_ADMIN
       - NET_ADMIN
+      - SYS_MODULE
+      - SYS_PTRACE
+      - MKNOD
+      - DAC_OVERRIDE
     security_opt:
       - seccomp:unconfined
+      - apparmor:unconfined
+    healthcheck:
+      test: ["CMD", "/usr/local/bin/health-check.sh"]
+      interval: 30s
+      timeout: 10s
+      retries: 3
+      start_period: 60s
+    depends_on:
+      - redis
+      - postgres
     networks:
       - marketing-net
 


### PR DESCRIPTION
## Summary
- expand Webtop dev stack with X11/DBus environment, extended volumes and devices
- add healthcheck and improved runtime capabilities

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: Cannot find package '@eslint/js')*


------
https://chatgpt.com/codex/tasks/task_b_688e5c60efa4832f8bcc4eb67f3bd185