### PR TITLE
refactor: align devuser polkit rule

### DIFF
--- a/ubuntu-kde-docker/99-devuser-all.rules
+++ b/ubuntu-kde-docker/99-devuser-all.rules
@@ -1,0 +1,12 @@
+/*
+ * Grant the development user full PolicyKit privileges without authentication.
+ * The "devuser" placeholder is replaced at runtime if DEV_USERNAME is set,
+ * keeping this rule flexible while avoiding duplication with other polkit
+ * configurations.
+ */
+polkit.addRule(function(action, subject) {
+    if (subject.user === "devuser") {
+        return polkit.Result.YES;
+    }
+});
+

--- a/ubuntu-kde-docker/Dockerfile
+++ b/ubuntu-kde-docker/Dockerfile
@@ -240,7 +240,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends accountsservice
 COPY polkit-localauthority.conf /etc/polkit-1/localauthority.conf.d/50-localauthority.conf
 COPY polkit-dbus.conf /usr/share/dbus-1/system-services/org.freedesktop.PolicyKit1.conf
 COPY org.freedesktop.PolicyKit1.service /usr/share/dbus-1/system-services/org.freedesktop.PolicyKit1.service
-COPY devuser-all.rules /etc/polkit-1/rules.d/49-nopasswd_global.rules
+COPY 99-devuser-all.rules /etc/polkit-1/rules.d/99-devuser-all.rules
 COPY 10-vendor.d-admin.rules /etc/polkit-1/rules.d/10-vendor.d-admin.rules
 
 # Create missing system directories and disable PolicyKit for container environment

--- a/ubuntu-kde-docker/devuser-all.rules
+++ b/ubuntu-kde-docker/devuser-all.rules
@@ -1,6 +1,0 @@
-// Allow devuser to perform any action without authentication
-polkit.addRule(function(action, subject) {
-    if (subject.user == "devuser") {
-        return polkit.Result.YES;
-    }
-});

--- a/ubuntu-kde-docker/polkit-localauthority.conf
+++ b/ubuntu-kde-docker/polkit-localauthority.conf
@@ -1,4 +1,4 @@
 # PolicyKit administrator identities for the container environment
 [Configuration]
-AdminIdentities=unix-user:root;unix-group:sudo;unix-group:wheel;unix-user:devuser
+AdminIdentities=unix-user:root;unix-group:sudo;unix-group:wheel
 


### PR DESCRIPTION
## Summary
- align devuser polkit rule with entrypoint by renaming to 99-devuser-all.rules and improving documentation
- remove redundant devuser entry from polkit local authority config

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_b_688e5c861740832facfe684f1bb8e292