### PR TITLE
refactor: improve virtual audio device script

### DIFF
--- a/ubuntu-kde-docker/create-virtual-audio-devices.sh
+++ b/ubuntu-kde-docker/create-virtual-audio-devices.sh
@@ -2,172 +2,130 @@
 # Virtual Audio Device Creation Script
 # Creates persistent virtual audio devices for container environment
 
-set -e
+set -euo pipefail
 
 DEV_USERNAME="${DEV_USERNAME:-devuser}"
 DEV_UID="${DEV_UID:-1000}"
 
 echo "🔊 Creating persistent virtual audio devices..."
 
-# Ensure proper environment setup
-export XDG_RUNTIME_DIR="/run/user/${DEV_UID}"
-export PULSE_RUNTIME_PATH="/run/user/${DEV_UID}/pulse"
+# Environment used when calling pactl as the dev user
+PA_ENV="export XDG_RUNTIME_DIR=/run/user/${DEV_UID}; export PULSE_RUNTIME_PATH=/run/user/${DEV_UID}/pulse"
 
-# Wait for PulseAudio to be ready
 wait_for_pulseaudio() {
     local timeout=60
     echo "⏳ Waiting for PulseAudio to be ready..."
-    
+
     while [ $timeout -gt 0 ]; do
-        # Try local socket first, then TCP fallback
-        if su - "${DEV_USERNAME}" -c "export XDG_RUNTIME_DIR=/run/user/${DEV_UID}; pactl info >/dev/null 2>&1"; then
+        if su - "$DEV_USERNAME" -c "$PA_ENV; pactl info" >/dev/null 2>&1; then
             echo "✅ PulseAudio is ready (local)"
             return 0
-        elif su - "${DEV_USERNAME}" -c "export XDG_RUNTIME_DIR=/run/user/${DEV_UID}; pactl -s tcp:localhost:4713 info >/dev/null 2>&1"; then
+        elif su - "$DEV_USERNAME" -c "$PA_ENV; pactl -s tcp:localhost:4713 info" >/dev/null 2>&1; then
             echo "✅ PulseAudio is ready (TCP)"
             return 0
         fi
-        
+
         if [ $((timeout % 10)) -eq 0 ]; then
             echo "Still waiting for PulseAudio... ($timeout seconds remaining)"
         fi
-        
+
         sleep 1
         timeout=$((timeout - 1))
     done
-    
+
     echo "❌ PulseAudio not ready after 60 seconds"
     echo "🔧 Attempting PulseAudio restart..."
-    
-    # Try to restart PulseAudio
-    su - "${DEV_USERNAME}" -c "
-        export XDG_RUNTIME_DIR=/run/user/${DEV_UID}
-        export PULSE_RUNTIME_PATH=/run/user/${DEV_UID}/pulse
+
+    su - "$DEV_USERNAME" -c "
+        $PA_ENV
         pkill -f pulseaudio || true
         sleep 2
         pulseaudio --daemonize --start
     "
-    
+
     sleep 5
-    if su - "${DEV_USERNAME}" -c "export XDG_RUNTIME_DIR=/run/user/${DEV_UID}; pactl info >/dev/null 2>&1"; then
+    if su - "$DEV_USERNAME" -c "$PA_ENV; pactl info" >/dev/null 2>&1; then
         echo "✅ PulseAudio restarted successfully"
         return 0
     fi
-    
+
     return 1
 }
 
-# Create virtual audio devices
+# Run pactl with a TCP fallback. Prints command output on success.
+pactl_cmd() {
+    local cmd="$1"
+    local output
+    if output=$(su - "$DEV_USERNAME" -c "$PA_ENV; pactl $cmd" 2>/dev/null); then
+        printf '%s\n' "$output"
+        return 0
+    elif output=$(su - "$DEV_USERNAME" -c "$PA_ENV; pactl -s tcp:localhost:4713 $cmd" 2>/dev/null); then
+        printf '%s\n' "$output"
+        return 0
+    else
+        return 1
+    fi
+}
+
 create_virtual_devices() {
     echo "🔧 Creating virtual audio devices..."
-    
-    # Function to run pactl with fallback servers
-    run_pactl() {
-        local cmd="$1"
-        # Try local socket first, then TCP fallback
-        if su - "${DEV_USERNAME}" -c "export XDG_RUNTIME_DIR=/run/user/${DEV_UID}; pactl $cmd >/dev/null 2>&1"; then
-            return 0
-        elif su - "${DEV_USERNAME}" -c "export XDG_RUNTIME_DIR=/run/user/${DEV_UID}; pactl -s tcp:localhost:4713 $cmd >/dev/null 2>&1"; then
-            return 0
-        else
-            return 1
-        fi
-    }
-    
-    # Create virtual speaker
-    if ! run_pactl "list short sinks" | grep -q virtual_speaker; then
+
+    if ! pactl_cmd "list short sinks" | grep -q virtual_speaker; then
         echo "Creating virtual speaker..."
-        if ! run_pactl "load-module module-null-sink sink_name=virtual_speaker sink_properties=device.description=\"Virtual_Marketing_Speaker\""; then
-            echo "⚠️ Failed to create virtual speaker, using fallback method"
-            su - "${DEV_USERNAME}" -c "
-                export XDG_RUNTIME_DIR=/run/user/${DEV_UID}
-                export PULSE_RUNTIME_PATH=/run/user/${DEV_UID}/pulse
-                pactl -s tcp:localhost:4713 load-module module-null-sink sink_name=virtual_speaker sink_properties=device.description=\"Virtual_Marketing_Speaker\" || true
-            "
-        fi
+        pactl_cmd "load-module module-null-sink sink_name=virtual_speaker sink_properties=device.description=\\\"Virtual_Marketing_Speaker\\\"" >/dev/null || echo "⚠️  Failed to create virtual speaker"
     else
         echo "✅ Virtual speaker already exists"
     fi
-    
-    # Create virtual microphone
-    if ! run_pactl "list short sinks" | grep -q virtual_microphone; then
+
+    if ! pactl_cmd "list short sinks" | grep -q virtual_microphone; then
         echo "Creating virtual microphone..."
-        if ! run_pactl "load-module module-null-sink sink_name=virtual_microphone sink_properties=device.description=\"Virtual_Marketing_Microphone\""; then
-            echo "⚠️ Failed to create virtual microphone, using fallback method"
-            su - "${DEV_USERNAME}" -c "
-                export XDG_RUNTIME_DIR=/run/user/${DEV_UID}
-                export PULSE_RUNTIME_PATH=/run/user/${DEV_UID}/pulse
-                pactl -s tcp:localhost:4713 load-module module-null-sink sink_name=virtual_microphone sink_properties=device.description=\"Virtual_Marketing_Microphone\" || true
-            "
-        fi
+        pactl_cmd "load-module module-null-sink sink_name=virtual_microphone sink_properties=device.description=\\\"Virtual_Marketing_Microphone\\\"" >/dev/null || echo "⚠️  Failed to create virtual microphone"
     else
         echo "✅ Virtual microphone already exists"
     fi
-    
-    # Create virtual microphone source
-    if ! run_pactl "list short sources" | grep -q virtual_mic_source; then
+
+    if ! pactl_cmd "list short sources" | grep -q virtual_mic_source; then
         echo "Creating virtual microphone source..."
-        if ! run_pactl "load-module module-virtual-source source_name=virtual_mic_source master=virtual_microphone.monitor source_properties=device.description=\"Virtual_Marketing_Mic_Source\""; then
-            echo "⚠️ Failed to create virtual microphone source, using fallback method"
-            su - "${DEV_USERNAME}" -c "
-                export XDG_RUNTIME_DIR=/run/user/${DEV_UID}
-                export PULSE_RUNTIME_PATH=/run/user/${DEV_UID}/pulse
-                pactl -s tcp:localhost:4713 load-module module-virtual-source source_name=virtual_mic_source master=virtual_microphone.monitor source_properties=device.description=\"Virtual_Marketing_Mic_Source\" || true
-            "
-        fi
+        pactl_cmd "load-module module-virtual-source source_name=virtual_mic_source master=virtual_microphone.monitor source_properties=device.description=\\\"Virtual_Marketing_Mic_Source\\\"" >/dev/null || echo "⚠️  Failed to create virtual microphone source"
     else
         echo "✅ Virtual microphone source already exists"
     fi
-    
-    # Set defaults with error handling
+
     echo "🎯 Setting default audio devices..."
-    su - "${DEV_USERNAME}" -c "
-        export XDG_RUNTIME_DIR=/run/user/${DEV_UID}
-        export PULSE_RUNTIME_PATH=/run/user/${DEV_UID}/pulse
-        
-        # Try local socket first, then TCP fallback
-        if pactl set-default-sink virtual_speaker 2>/dev/null; then
-            echo 'Set default sink via local socket'
-        elif pactl -s tcp:localhost:4713 set-default-sink virtual_speaker 2>/dev/null; then
-            echo 'Set default sink via TCP'
-        fi
-        
-        if pactl set-default-source virtual_mic_source 2>/dev/null; then
-            echo 'Set default source via local socket'
-        elif pactl -s tcp:localhost:4713 set-default-source virtual_mic_source 2>/dev/null; then
-            echo 'Set default source via TCP'
-        fi
-        
-        # Set volume levels
+    su - "$DEV_USERNAME" -c "
+        $PA_ENV
+        pactl set-default-sink virtual_speaker 2>/dev/null || pactl -s tcp:localhost:4713 set-default-sink virtual_speaker 2>/dev/null || true
+        pactl set-default-source virtual_mic_source 2>/dev/null || pactl -s tcp:localhost:4713 set-default-source virtual_mic_source 2>/dev/null || true
         pactl set-sink-volume virtual_speaker 50% 2>/dev/null || pactl -s tcp:localhost:4713 set-sink-volume virtual_speaker 50% 2>/dev/null || true
         pactl set-sink-volume virtual_microphone 50% 2>/dev/null || pactl -s tcp:localhost:4713 set-sink-volume virtual_microphone 50% 2>/dev/null || true
     "
-    
+
     echo "✅ Virtual audio devices created successfully"
 }
 
-# Verify devices are working
 verify_devices() {
     echo "🔍 Verifying virtual audio devices..."
-    
-    local sink_count
-    local source_count
-    
-    sink_count=$(su - "${DEV_USERNAME}" -c "export XDG_RUNTIME_DIR=/run/user/${DEV_UID}; pactl list short sinks | wc -l")
-    source_count=$(su - "${DEV_USERNAME}" -c "export XDG_RUNTIME_DIR=/run/user/${DEV_UID}; pactl list short sources | wc -l")
-    
+
+    local sink_count source_count
+
+    if ! sink_count=$(pactl_cmd "list short sinks" | wc -l); then
+        echo "❌ Failed to list sinks"
+        return 1
+    fi
+
+    if ! source_count=$(pactl_cmd "list short sources" | wc -l); then
+        echo "❌ Failed to list sources"
+        return 1
+    fi
+
     echo "Found $sink_count sinks and $source_count sources"
-    
+
     if [ "$sink_count" -gt 0 ] && [ "$source_count" -gt 0 ]; then
         echo "✅ Audio devices verification successful"
-        
-        # List devices for confirmation
         echo "Available sinks:"
-        su - "${DEV_USERNAME}" -c "export XDG_RUNTIME_DIR=/run/user/${DEV_UID}; pactl list short sinks"
-        
+        pactl_cmd "list short sinks"
         echo "Available sources:"
-        su - "${DEV_USERNAME}" -c "export XDG_RUNTIME_DIR=/run/user/${DEV_UID}; pactl list short sources"
-        
+        pactl_cmd "list short sources"
         return 0
     else
         echo "❌ Audio devices verification failed"
@@ -175,24 +133,21 @@ verify_devices() {
     fi
 }
 
-# Main execution
 main() {
-    # Check if user exists
-    if ! id "${DEV_USERNAME}" >/dev/null 2>&1; then
+    if ! id "$DEV_USERNAME" >/dev/null 2>&1; then
         echo "❌ User ${DEV_USERNAME} doesn't exist yet"
         exit 1
     fi
-    
-    # Ensure runtime directory exists
+
     mkdir -p "/run/user/${DEV_UID}/pulse"
     chown -R "${DEV_USERNAME}:${DEV_USERNAME}" "/run/user/${DEV_UID}"
-    
-    # Execute the device creation process
+
     wait_for_pulseaudio
     create_virtual_devices
     verify_devices
-    
+
     echo "🎵 Virtual audio device setup completed successfully!"
 }
 
 main "$@"
+


### PR DESCRIPTION
## Summary
- simplify virtual audio device creation and defaults
- add robust pactl helper with TCP fallback
- improve PulseAudio startup handling and verification

## Testing
- `bash -n ubuntu-kde-docker/create-virtual-audio-devices.sh`
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(warnings: react-refresh/only-export-components)*

------
https://chatgpt.com/codex/tasks/task_b_688e5ca7cbcc832fb00ce93ff662a56f