### PR TITLE
refactor auth setup script

### DIFF
--- a/ubuntu-kde-docker/auth-setup.sh
+++ b/ubuntu-kde-docker/auth-setup.sh
@@ -5,41 +5,17 @@
 
 set -e
 
-# Color codes
-RED='\033[0;31m'
-GREEN='\033[0;32m'
-YELLOW='\033[1;33m'
-BLUE='\033[0;34m'
-NC='\033[0m'
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# Reuse common logging utilities
+source "$SCRIPT_DIR/lib/core.sh"
 
 # Default paths
-HTPASSWD_FILE="auth/.htpasswd"
-AUTH_DIR="auth"
+HTPASSWD_FILE="$SCRIPT_DIR/auth/.htpasswd"
+AUTH_DIR="$SCRIPT_DIR/auth"
 
-print_status() {
-    echo -e "${BLUE}[INFO]${NC} $1"
-}
-
-print_success() {
-    echo -e "${GREEN}[SUCCESS]${NC} $1"
-}
-
-print_warning() {
-    echo -e "${YELLOW}[WARNING]${NC} $1"
-}
-
-print_error() {
-    echo -e "${RED}[ERROR]${NC} $1"
-}
-
-# Initialize auth directory and files
+# Initialize auth directory
 init_auth() {
     mkdir -p "$AUTH_DIR"
-    
-    if [[ ! -f "$HTPASSWD_FILE" ]]; then
-        touch "$HTPASSWD_FILE"
-        print_success "Created authentication file: $HTPASSWD_FILE"
-    fi
 }
 
 # Add or update user
@@ -72,12 +48,16 @@ add_user() {
     fi
     
     # Add or update user
-    if grep -q "^${username}:" "$HTPASSWD_FILE" 2>/dev/null; then
+    if [[ -f "$HTPASSWD_FILE" ]] && grep -q "^${username}:" "$HTPASSWD_FILE" 2>/dev/null; then
         print_status "Updating existing user: $username"
         htpasswd -b "$HTPASSWD_FILE" "$username" "$password"
     else
         print_status "Adding new user: $username"
-        htpasswd -bc "$HTPASSWD_FILE" "$username" "$password" 2>/dev/null || htpasswd -b "$HTPASSWD_FILE" "$username" "$password"
+        if [[ ! -f "$HTPASSWD_FILE" || ! -s "$HTPASSWD_FILE" ]]; then
+            htpasswd -bc "$HTPASSWD_FILE" "$username" "$password"
+        else
+            htpasswd -b "$HTPASSWD_FILE" "$username" "$password"
+        fi
     fi
     
     print_success "User $username configured successfully"
@@ -164,6 +144,28 @@ generate_auth_from_env() {
     print_success "Authentication configured from environment file"
 }
 
+# Setup authentication for a container
+setup_container_auth() {
+    local container_name="$1"
+
+    if [[ -z "$container_name" ]]; then
+        print_error "Usage: setup <container_name>"
+        return 1
+    fi
+
+    init_auth
+
+    if [[ ! -f "$HTPASSWD_FILE" ]]; then
+        print_warning "No authentication file found to copy"
+        return 0
+    fi
+
+    local dest="${DATA_ROOT:-/data/ubuntu-kde-docker}/$container_name/auth"
+    mkdir -p "$dest"
+    cp "$HTPASSWD_FILE" "$dest/.htpasswd"
+    print_success "Authentication configured for container: $container_name"
+}
+
 # Main function
 main() {
     case "${1:-}" in
@@ -188,8 +190,11 @@ main() {
         "generate")
             generate_auth_from_env "$2"
             ;;
+        "setup")
+            setup_container_auth "$2"
+            ;;
         *)
-            echo "Usage: $0 {add|remove|list|init|generate} [options]"
+            echo "Usage: $0 {add|remove|list|init|generate|setup} [options]"
             echo ""
             echo "Commands:"
             echo "  add <user:pass>     Add or update user"
@@ -198,12 +203,14 @@ main() {
             echo "  list                List all users"
             echo "  init                Initialize auth directory"
             echo "  generate [env_file] Generate auth from environment file"
+            echo "  setup <container>   Copy auth file for container"
             echo ""
             echo "Examples:"
             echo "  $0 add admin:secure123"
             echo "  $0 add client1 password123"
             echo "  $0 remove client1"
             echo "  $0 generate .env"
+            echo "  $0 setup my-container"
             exit 1
             ;;
     esac


### PR DESCRIPTION
## Summary
- source shared logging utils instead of redefining them
- fix htpasswd handling and add container auth setup helper
- improve path handling and usage messages

## Testing
- `bash -n ubuntu-kde-docker/auth-setup.sh`
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_b_688e5cd5f8d0832f92e1b7d0e9c3fa3a