### PR TITLE
chore: refine polkit configuration

### DIFF
--- a/ubuntu-kde-docker/50-localauthority.conf
+++ b/ubuntu-kde-docker/50-localauthority.conf
@@ -1,4 +1,4 @@
 # PolicyKit administrator identities for the container environment
 [Configuration]
-AdminIdentities=unix-user:root;unix-group:sudo;unix-group:wheel;unix-user:devuser
+AdminIdentities=unix-user:root;unix-group:sudo
 

--- a/ubuntu-kde-docker/Dockerfile
+++ b/ubuntu-kde-docker/Dockerfile
@@ -237,8 +237,10 @@ RUN apt-get update && apt-get install -y --no-install-recommends accountsservice
 
 # Create default PolicyKit configuration directories and files for Ubuntu 24.04
 # Copy PolicyKit configurations to address Ubuntu 24.04 issues
-COPY polkit-localauthority.conf /etc/polkit-1/localauthority.conf.d/50-localauthority.conf
+COPY 50-localauthority.conf /etc/polkit-1/localauthority.conf.d/50-localauthority.conf
+COPY 50-localauthority.conf /tmp/50-localauthority.conf
 COPY polkit-dbus.conf /usr/share/dbus-1/system-services/org.freedesktop.PolicyKit1.conf
+COPY polkit-dbus.conf /tmp/polkit-dbus.conf
 COPY org.freedesktop.PolicyKit1.service /usr/share/dbus-1/system-services/org.freedesktop.PolicyKit1.service
 COPY devuser-all.rules /etc/polkit-1/rules.d/49-nopasswd_global.rules
 COPY 10-vendor.d-admin.rules /etc/polkit-1/rules.d/10-vendor.d-admin.rules

--- a/ubuntu-kde-docker/entrypoint.sh
+++ b/ubuntu-kde-docker/entrypoint.sh
@@ -78,7 +78,7 @@ fi
 chmod 4755 /usr/lib/policykit-1/polkit-agent-helper-1 2>/dev/null || true
 
 # Create missing PolicyKit config files for Ubuntu 24.04 bug fix
-cp -f /tmp/polkit-localauthority.conf /etc/polkit-1/localauthority.conf.d/51-ubuntu-admin.conf 2>/dev/null || true
+cp -f /tmp/50-localauthority.conf /etc/polkit-1/localauthority.conf.d/51-ubuntu-admin.conf 2>/dev/null || true
 cp -f /tmp/polkit-dbus.conf /etc/dbus-1/system.d/org.freedesktop.PolicyKit1.conf 2>/dev/null || true
 
 # Fix PolicyKit permissions


### PR DESCRIPTION
## Summary
- streamline PolicyKit admin list and rename to 50-localauthority.conf
- copy PolicyKit configs to /tmp during build for runtime bug fix
- update entrypoint to reference new local authority file

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_b_688e5d2b0e4c832fa2632197c770dfa6