### PR TITLE
chore: streamline polkit admin rules

### DIFF
--- a/ubuntu-kde-docker/10-vendor.d-admin.rules
+++ b/ubuntu-kde-docker/10-vendor.d-admin.rules
@@ -1,13 +1,6 @@
-// Allow members of the sudo group to execute actions without authentication
+// Allow members of the sudo group and the polkitd user to execute actions without authentication
 polkit.addRule(function(action, subject) {
-    if (subject.isInGroup("sudo")) {
-        return polkit.Result.YES;
-    }
-});
-
-// Allow the polkitd user to perform system actions
-polkit.addRule(function(action, subject) {
-    if (subject.user == "polkitd") {
+    if (subject.isInGroup("sudo") || subject.user == "polkitd") {
         return polkit.Result.YES;
     }
 });


### PR DESCRIPTION
## Summary
- consolidate polkit rules to allow sudo and polkitd without auth

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_b_688e5d3e1474832fb76c4f5e6a992a36