### PR TITLE
feat: seed container registry with default webtop entry

### DIFF
--- a/ubuntu-kde-docker/.container-registry.json
+++ b/ubuntu-kde-docker/.container-registry.json
@@ -1,1 +1,14 @@
-{}
+{
+  "kde": {
+    "name": "webtop-kde",
+    "ports": {
+      "http": 32768,
+      "ssh": 2222,
+      "ttyd": 7681,
+      "audio": 8080,
+      "pulse": 4713
+    },
+    "created": "2024-01-01T00:00:00Z",
+    "status": "running"
+  }
+}


### PR DESCRIPTION
## Summary
- pre-populate container registry with default webtop-kde metadata

## Testing
- `npm ci`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_b_688e5d55e1e8832fbaabf47e19d20179