### PR TITLE
fix polkit configuration handling

### DIFF
--- a/ubuntu-kde-docker/50-localauthority.conf
+++ b/ubuntu-kde-docker/50-localauthority.conf
@@ -1,4 +1,3 @@
 # PolicyKit administrator identities for the container environment
 [Configuration]
 AdminIdentities=unix-user:root;unix-group:sudo;unix-group:wheel
-

--- a/ubuntu-kde-docker/Dockerfile
+++ b/ubuntu-kde-docker/Dockerfile
@@ -237,8 +237,8 @@ RUN apt-get update && apt-get install -y --no-install-recommends accountsservice
 
 # Create default PolicyKit configuration directories and files for Ubuntu 24.04
 # Copy PolicyKit configurations to address Ubuntu 24.04 issues
-COPY polkit-localauthority.conf /etc/polkit-1/localauthority.conf.d/50-localauthority.conf
-COPY polkit-dbus.conf /usr/share/dbus-1/system-services/org.freedesktop.PolicyKit1.conf
+COPY 50-localauthority.conf /etc/polkit-1/localauthority.conf.d/50-localauthority.conf
+COPY polkit-dbus.conf /etc/dbus-1/system.d/org.freedesktop.PolicyKit1.conf
 COPY org.freedesktop.PolicyKit1.service /usr/share/dbus-1/system-services/org.freedesktop.PolicyKit1.service
 COPY 99-devuser-all.rules /etc/polkit-1/rules.d/99-devuser-all.rules
 COPY 10-vendor.d-admin.rules /etc/polkit-1/rules.d/10-vendor.d-admin.rules

--- a/ubuntu-kde-docker/entrypoint.sh
+++ b/ubuntu-kde-docker/entrypoint.sh
@@ -77,10 +77,6 @@ if command -v setcap >/dev/null 2>&1; then
 fi
 chmod 4755 /usr/lib/policykit-1/polkit-agent-helper-1 2>/dev/null || true
 
-# Create missing PolicyKit config files for Ubuntu 24.04 bug fix
-cp -f /tmp/polkit-localauthority.conf /etc/polkit-1/localauthority.conf.d/51-ubuntu-admin.conf 2>/dev/null || true
-cp -f /tmp/polkit-dbus.conf /etc/dbus-1/system.d/org.freedesktop.PolicyKit1.conf 2>/dev/null || true
-
 # Fix PolicyKit permissions
 chown polkitd:polkitd /var/lib/polkit-1/localauthority 2>/dev/null || true
 chmod 755 /var/lib/polkit-1/localauthority 2>/dev/null || true


### PR DESCRIPTION
## Summary
- rename and streamline PolicyKit local authority configuration
- correct Dockerfile PolicyKit copy paths
- drop redundant runtime PolicyKit copies in entrypoint

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_b_688e65996b2c832fb7176001a4e8a7eb