### PR TITLE
refactor build manager file handling

### DIFF
--- a/ubuntu-kde-docker/lib/build-manager.sh
+++ b/ubuntu-kde-docker/lib/build-manager.sh
@@ -3,17 +3,30 @@
 # Build management functions with background build support
 # Part of the modular webtop.sh refactoring
 
+# Helper functions for build file names
+get_build_pid_file() {
+    local config="$1"
+    echo "build-${config}.pid"
+}
+
+get_build_log_file() {
+    local config="$1"
+    echo "build-${config}.log"
+}
+
 # Build Docker image
 build_image() {
-    local config=$(get_config "$1")
-    local compose_file=$(get_compose_file "$config")
+    local config
+    config=$(get_config "$1")
+    local compose_file
+    compose_file=$(get_compose_file "$config")
     local background_flag="$2"
-    
+
     if [ ! -f "$compose_file" ]; then
         print_error "Docker Compose file not found: $compose_file"
         exit 1
     fi
-    
+
     if [ "$background_flag" = "--background" ] || [ "$background_flag" = "bg" ]; then
         build_image_background "$config" "$compose_file"
     else
@@ -27,24 +40,29 @@ build_image() {
 build_image_background() {
     local config="$1"
     local compose_file="$2"
-    local pid_file="build-${config}.pid"
-    local log_file="build-${config}.log"
-    local start_time=$(date +%s)
-    
+    local pid_file
+    pid_file=$(get_build_pid_file "$config")
+    local log_file
+    log_file=$(get_build_log_file "$config")
+    local start_time
+    start_time=$(date +%s)
+
     # Check if build is already running
     if [ -f "$pid_file" ] && kill -0 "$(cat "$pid_file")" 2>/dev/null; then
         print_warning "Background build already running for ${config} configuration"
         print_status "Check progress with: $0 build-status --${config}"
         return 0
     fi
-    
+
     print_status "Starting background build (${config} configuration)..."
-    echo "Build started at: $(date)" > "$log_file"
-    echo "Configuration: $config" >> "$log_file"
-    echo "Compose file: $compose_file" >> "$log_file"
-    echo "Start time: $start_time" >> "$log_file"
-    echo "========================================" >> "$log_file"
-    
+    {
+        echo "Build started at: $(date)"
+        echo "Configuration: $config"
+        echo "Compose file: $compose_file"
+        echo "Start time: $start_time"
+        echo "========================================"
+    } > "$log_file"
+
     # Start background build process
     nohup bash -c "
         echo 'Build process started' >> '$log_file'
@@ -60,10 +78,10 @@ build_image_background() {
         fi
         rm -f '$pid_file'
     " > /dev/null 2>&1 &
-    
+
     local build_pid=$!
     echo "$build_pid" > "$pid_file"
-    
+
     print_success "Background build started (PID: $build_pid)"
     print_status "Check progress with: $0 build-status"
     print_status "View logs with: $0 build-logs"
@@ -72,21 +90,25 @@ build_image_background() {
 
 # Check background build status
 check_build_status() {
-    local config=$(get_config "$1")
-    local pid_file="build-${config}.pid"
-    local log_file="build-${config}.log"
-    
+    local config
+    config=$(get_config "$1")
+    local pid_file
+    pid_file=$(get_build_pid_file "$config")
+    local log_file
+    log_file=$(get_build_log_file "$config")
+
     if [ ! -f "$log_file" ]; then
         print_warning "No build log found for ${config} configuration"
         return 1
     fi
-    
+
     # Check if build is running
     if [ -f "$pid_file" ] && kill -0 "$(cat "$pid_file")" 2>/dev/null; then
-        local pid=$(cat "$pid_file")
+        local pid
+        pid=$(cat "$pid_file")
         print_status "Background build running (PID: $pid) - ${config} configuration"
         echo
-        
+
         # Show recent progress
         echo -e "${CYAN}Recent build output:${NC}"
         tail -10 "$log_file"
@@ -103,7 +125,7 @@ check_build_status() {
         else
             print_warning "Build status unclear. Check logs with: $0 build-logs"
         fi
-        
+
         # Show build summary
         if [ -f "$log_file" ]; then
             echo
@@ -115,18 +137,20 @@ check_build_status() {
 
 # Show build logs
 show_build_logs() {
-    local config=$(get_config "$1")
-    local log_file="build-${config}.log"
+    local config
+    config=$(get_config "$1")
+    local log_file
+    log_file=$(get_build_log_file "$config")
     local follow_flag="$2"
-    
+
     if [ ! -f "$log_file" ]; then
         print_warning "No build log found for ${config} configuration"
         return 1
     fi
-    
+
     print_status "Build logs for ${config} configuration:"
     echo
-    
+
     if [ "$follow_flag" = "-f" ] || [ "$follow_flag" = "--follow" ]; then
         tail -f "$log_file"
     else
@@ -136,34 +160,40 @@ show_build_logs() {
 
 # Stop background build
 stop_build() {
-    local config=$(get_config "$1")
-    local pid_file="build-${config}.pid"
-    local log_file="build-${config}.log"
-    
+    local config
+    config=$(get_config "$1")
+    local pid_file
+    pid_file=$(get_build_pid_file "$config")
+    local log_file
+    log_file=$(get_build_log_file "$config")
+
     if [ ! -f "$pid_file" ]; then
         print_warning "No background build running for ${config} configuration"
         return 1
     fi
-    
-    local pid=$(cat "$pid_file")
-    
+
+    local pid
+    pid=$(cat "$pid_file")
+
     if kill -0 "$pid" 2>/dev/null; then
         print_status "Stopping background build (PID: $pid)..."
-        
+
         # Try graceful termination first
         kill -TERM "$pid" 2>/dev/null
         sleep 2
-        
+
         # Force kill if still running
         if kill -0 "$pid" 2>/dev/null; then
             kill -KILL "$pid" 2>/dev/null
         fi
-        
+
         # Log the interruption
-        echo "========================================" >> "$log_file"
-        echo "Build stopped by user at: $(date)" >> "$log_file"
-        echo "Status: INTERRUPTED" >> "$log_file"
-        
+        {
+            echo "========================================"
+            echo "Build stopped by user at: $(date)"
+            echo "Status: INTERRUPTED"
+        } >> "$log_file"
+
         rm -f "$pid_file"
         print_success "Background build stopped"
     else
@@ -175,15 +205,17 @@ stop_build() {
 # Cleanup build files
 cleanup_build_files() {
     local config="$1"
-    
+
     if [ "$config" = "all" ]; then
         print_status "Cleaning up all build files..."
         rm -f build-*.pid build-*.log
         print_success "All build files cleaned up"
     else
-        local actual_config=$(get_config "$config")
+        local actual_config
+        actual_config=$(get_config "$config")
         print_status "Cleaning up build files for ${actual_config} configuration..."
-        rm -f "build-${actual_config}.pid" "build-${actual_config}.log"
+        rm -f "$(get_build_pid_file "$actual_config")" "$(get_build_log_file "$actual_config")"
         print_success "Build files for ${actual_config} configuration cleaned up"
     fi
 }
+


### PR DESCRIPTION
## Summary
- add helper functions for build log and PID files
- consolidate background build logging and cleanup using helpers

## Testing
- `shellcheck ubuntu-kde-docker/lib/build-manager.sh`
- `npm test` *(fails: Missing script: "test")*
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_b_688e663ac950832fb629f1acc393ff54