### PR TITLE
Refactor registry management script

### DIFF
--- a/ubuntu-kde-docker/lib/registry.sh
+++ b/ubuntu-kde-docker/lib/registry.sh
@@ -3,38 +3,49 @@
 # Container registry management functions
 # Part of the modular webtop.sh refactoring
 
-# Get assigned ports for container
-get_container_ports() {
-    local container_name=$1
-    
+# Ensure registry exists and jq is available
+ensure_registry() {
     ensure_jq
-    
     if [ ! -f "$CONTAINER_REGISTRY" ]; then
         echo "{}" > "$CONTAINER_REGISTRY"
     fi
-    
+}
+
+# Check if a container exists in registry
+container_exists() {
+    local name="$1"
+    ensure_registry
+    jq -e ".\"$name\"" "$CONTAINER_REGISTRY" > /dev/null 2>&1
+}
+
+# Get assigned ports for container
+get_container_ports() {
+    local container_name="$1"
+
+    ensure_registry
+
     # Check if container already has assigned ports
-    if jq -e ".\"$container_name\"" "$CONTAINER_REGISTRY" > /dev/null 2>&1; then
-        local http_port=$(jq -r ".\"$container_name\".ports.http" "$CONTAINER_REGISTRY")
-        local ssh_port=$(jq -r ".\"$container_name\".ports.ssh" "$CONTAINER_REGISTRY")
-        local ttyd_port=$(jq -r ".\"$container_name\".ports.ttyd" "$CONTAINER_REGISTRY")
-        local audio_port=$(jq -r ".\"$container_name\".ports.audio" "$CONTAINER_REGISTRY")
-        local pulse_port=$(jq -r ".\"$container_name\".ports.pulse" "$CONTAINER_REGISTRY")
-        
+    if container_exists "$container_name"; then
+        local http_port ssh_port ttyd_port audio_port pulse_port
+        read -r http_port ssh_port ttyd_port audio_port pulse_port < <(
+            jq -r ".\"$container_name\".ports | [.http,.ssh,.ttyd,.audio,.pulse] | @tsv" "$CONTAINER_REGISTRY"
+        )
         echo "$http_port:80,$ssh_port:22,$ttyd_port:7681,$audio_port:8080,$pulse_port:4713"
         return
     fi
-    
+
     # Find available ports
     load_env
-    local http_port=$(find_available_port $BASE_HTTP_PORT)
-    local ssh_port=$(find_available_port $BASE_SSH_PORT)
-    local ttyd_port=$(find_available_port $BASE_TTYD_PORT)
-    local audio_port=$(find_available_port $BASE_AUDIO_PORT)
-    local pulse_port=$(find_available_port $BASE_PULSE_PORT)
-    
+    local http_port ssh_port ttyd_port audio_port pulse_port
+    http_port=$(find_available_port "$BASE_HTTP_PORT")
+    ssh_port=$(find_available_port "$BASE_SSH_PORT")
+    ttyd_port=$(find_available_port "$BASE_TTYD_PORT")
+    audio_port=$(find_available_port "$BASE_AUDIO_PORT")
+    pulse_port=$(find_available_port "$BASE_PULSE_PORT")
+
     # Store in registry
-    local temp_file=$(mktemp)
+    local temp_file
+    temp_file=$(mktemp)
     jq ".\"$container_name\" = {
         \"name\": \"webtop-$container_name\",
         \"ports\": {
@@ -47,126 +58,109 @@ get_container_ports() {
         \"created\": \"$(date -u +%Y-%m-%dT%H:%M:%SZ)\",
         \"status\": \"assigned\"
     }" "$CONTAINER_REGISTRY" > "$temp_file" && mv "$temp_file" "$CONTAINER_REGISTRY"
-    
+
     echo "$http_port:80,$ssh_port:22,$ttyd_port:7681,$audio_port:8080,$pulse_port:4713"
 }
 
 # List all managed containers
 list_containers() {
-    if [ ! -f "$CONTAINER_REGISTRY" ]; then
-        print_warning "No containers registered yet"
-        return 0
-    fi
-    
-    print_status "Managed Containers:"
-    echo
-    
-    local containers=$(jq -r 'keys[]' "$CONTAINER_REGISTRY" 2>/dev/null)
-    if [ -z "$containers" ]; then
+    ensure_registry
+
+    local entries
+    entries=$(jq -r 'to_entries[] | "\(.key) \(.value.name) \(.value.status) \(.value.ports.http) \(.value.ports.ssh)"' "$CONTAINER_REGISTRY" 2>/dev/null)
+
+    if [ -z "$entries" ]; then
         print_warning "No containers found in registry"
         return 0
     fi
-    
+
+    print_status "Managed Containers:"
+    echo
     printf "%-15s %-20s %-10s %-15s %-10s\n" "NAME" "CONTAINER" "STATUS" "HTTP_PORT" "SSH_PORT"
     printf "%-15s %-20s %-10s %-15s %-10s\n" "----" "---------" "------" "---------" "--------"
-    
-    for container in $containers; do
-        local container_id=$(jq -r ".\"$container\".name" "$CONTAINER_REGISTRY")
-        local status=$(jq -r ".\"$container\".status" "$CONTAINER_REGISTRY")
-        local http_port=$(jq -r ".\"$container\".ports.http" "$CONTAINER_REGISTRY")
-        local ssh_port=$(jq -r ".\"$container\".ports.ssh" "$CONTAINER_REGISTRY")
-        
-        # Check if container is actually running
-        if docker ps --format "table {{.Names}}" | grep -q "^$container_id$"; then
+
+    while read -r name container_id status http_port ssh_port; do
+        if docker ps --format '{{.Names}}' | grep -q "^$container_id$"; then
             status="running"
         else
             status="stopped"
         fi
-        
-        printf "%-15s %-20s %-10s %-15s %-10s\n" "$container" "$container_id" "$status" "$http_port" "$ssh_port"
-    done
+        printf "%-15s %-20s %-10s %-15s %-10s\n" "$name" "$container_id" "$status" "$http_port" "$ssh_port"
+    done <<< "$entries"
     echo
 }
 
 # Remove specific container
 remove_container() {
     local container_name="$1"
-    
+
     if [ -z "$container_name" ]; then
         print_error "Container name required"
         echo "Usage: $0 remove <container_name>"
         exit 1
     fi
-    
-    if [ ! -f "$CONTAINER_REGISTRY" ]; then
-        print_error "Container registry not found"
-        exit 1
-    fi
-    
-    # Check if container exists in registry
-    if ! jq -e ".\"$container_name\"" "$CONTAINER_REGISTRY" > /dev/null 2>&1; then
+
+    if ! container_exists "$container_name"; then
         print_error "Container '$container_name' not found in registry"
         exit 1
     fi
-    
+
     local container_id="webtop-$container_name"
-    
+
     print_status "Removing container: $container_name"
-    
+
     # Stop and remove the container
-    if docker ps -a --format "table {{.Names}}" | grep -q "^$container_id$"; then
+    if docker ps -a --format '{{.Names}}' | grep -q "^$container_id$"; then
         docker stop "$container_id" 2>/dev/null || true
         docker rm "$container_id" 2>/dev/null || true
         print_success "Container '$container_id' stopped and removed"
     fi
-    
+
     # Remove volumes
-    local volumes=$(docker volume ls --format "table {{.Name}}" | grep "^${container_name}_" || true)
+    local volumes
+    volumes=$(docker volume ls --format '{{.Name}}' | grep "^${container_name}_" || true)
     if [ -n "$volumes" ]; then
         echo "$volumes" | xargs docker volume rm 2>/dev/null || true
         print_success "Container volumes removed"
     fi
-    
+
     # Remove from registry
-    local temp_file=$(mktemp)
+    local temp_file
+    temp_file=$(mktemp)
     jq "del(.\"$container_name\")" "$CONTAINER_REGISTRY" > "$temp_file" && mv "$temp_file" "$CONTAINER_REGISTRY"
-    
+
     print_success "Container '$container_name' removed from registry"
 }
 
 # Show container info
 show_container_info() {
     local container_name="$1"
-    
+
     if [ -z "$container_name" ]; then
         print_error "Container name required"
         echo "Usage: $0 info <container_name>"
         exit 1
     fi
-    
-    if [ ! -f "$CONTAINER_REGISTRY" ] || ! jq -e ".\"$container_name\"" "$CONTAINER_REGISTRY" > /dev/null 2>&1; then
+
+    if ! container_exists "$container_name"; then
         print_error "Container '$container_name' not found in registry"
         exit 1
     fi
-    
+
     show_named_container_info "$container_name"
 }
 
 # Show named container access information
 show_named_container_info() {
     local container_name="$1"
-    
-    if [ ! -f "$CONTAINER_REGISTRY" ]; then
-        print_error "Container registry not found"
-        return 1
-    fi
-    
-    local http_port=$(jq -r ".\"$container_name\".ports.http" "$CONTAINER_REGISTRY")
-    local ssh_port=$(jq -r ".\"$container_name\".ports.ssh" "$CONTAINER_REGISTRY")
-    local ttyd_port=$(jq -r ".\"$container_name\".ports.ttyd" "$CONTAINER_REGISTRY")
-    local audio_port=$(jq -r ".\"$container_name\".ports.audio" "$CONTAINER_REGISTRY")
-    local pulse_port=$(jq -r ".\"$container_name\".ports.pulse" "$CONTAINER_REGISTRY")
-    
+
+    ensure_registry
+
+    local http_port ssh_port ttyd_port audio_port pulse_port
+    read -r http_port ssh_port ttyd_port audio_port pulse_port < <(
+        jq -r ".\"$container_name\".ports | [.http,.ssh,.ttyd,.audio,.pulse] | @tsv" "$CONTAINER_REGISTRY"
+    )
+
     echo
     print_success "Container '$container_name' is running!"
     echo
@@ -187,23 +181,24 @@ show_named_container_info() {
 # Open container in browser
 open_container() {
     local container_name="$1"
-    
+
     if [ -z "$container_name" ]; then
         print_error "Container name required"
         echo "Usage: $0 open <container_name>"
         exit 1
     fi
-    
-    if [ ! -f "$CONTAINER_REGISTRY" ] || ! jq -e ".\"$container_name\"" "$CONTAINER_REGISTRY" > /dev/null 2>&1; then
+
+    if ! container_exists "$container_name"; then
         print_error "Container '$container_name' not found in registry"
         exit 1
     fi
-    
-    local http_port=$(jq -r ".\"$container_name\".ports.http" "$CONTAINER_REGISTRY")
+
+    local http_port
+    http_port=$(jq -r ".\"$container_name\".ports.http" "$CONTAINER_REGISTRY")
     local url="http://localhost:$http_port"
-    
+
     print_status "Opening container '$container_name' at $url"
-    
+
     if command -v xdg-open > /dev/null; then
         xdg-open "$url"
     elif command -v open > /dev/null; then
@@ -216,20 +211,21 @@ open_container() {
 # Connect to container via SSH
 connect_container() {
     local container_name="$1"
-    
+
     if [ -z "$container_name" ]; then
         print_error "Container name required"
         echo "Usage: $0 connect <container_name>"
         exit 1
     fi
-    
-    if [ ! -f "$CONTAINER_REGISTRY" ] || ! jq -e ".\"$container_name\"" "$CONTAINER_REGISTRY" > /dev/null 2>&1; then
+
+    if ! container_exists "$container_name"; then
         print_error "Container '$container_name' not found in registry"
         exit 1
     fi
-    
-    local ssh_port=$(jq -r ".\"$container_name\".ports.ssh" "$CONTAINER_REGISTRY")
-    
+
+    local ssh_port
+    ssh_port=$(jq -r ".\"$container_name\".ports.ssh" "$CONTAINER_REGISTRY")
+
     print_status "Connecting to container '$container_name' via SSH on port $ssh_port"
     ssh devuser@localhost -p "$ssh_port"
 }


### PR DESCRIPTION
## Summary
- centralize registry checks with new helper utilities
- streamline port assignment and container listing logic
- simplify container info, open, and connect workflows

## Testing
- `shellcheck ubuntu-kde-docker/lib/registry.sh`
- `bash -n ubuntu-kde-docker/lib/registry.sh`
- `npm test` *(fails: Missing script: "test")*

------
https://chatgpt.com/codex/tasks/task_b_688e6693a958832f93b8ac7986a6d040