### PR TITLE
Improve container service resilience in headless environments

### DIFF
--- a/ubuntu-kde-docker/audio-monitor.sh
+++ b/ubuntu-kde-docker/audio-monitor.sh
@@ -8,6 +8,12 @@ DEV_USERNAME="${DEV_USERNAME:-devuser}"
 DEV_UID="${DEV_UID:-1000}"
 LOG_FILE="/var/log/supervisor/audio-monitor.log"
 
+# Skip monitoring entirely if running in headless mode
+if [ "${HEADLESS_MODE:-false}" = "true" ]; then
+    echo "$(date '+%Y-%m-%d %H:%M:%S') [AUDIO] Headless mode - skipping audio monitor" | tee -a "$LOG_FILE"
+    exit 0
+fi
+
 get_dev_uid() {
     id -u "$DEV_USERNAME" 2>/dev/null || echo "$DEV_UID"
 }

--- a/ubuntu-kde-docker/entrypoint.sh
+++ b/ubuntu-kde-docker/entrypoint.sh
@@ -24,12 +24,13 @@ log_info "🚀 Starting Ubuntu KDE Marketing Agency WebTop..."
 : "${TTYD_PASSWORD:=TerminalPassw0rd!}"
 : "${ENABLE_GOOGLE_ADS_EDITOR:=false}"
 : "${XSTARTUP_SRC:=/usr/local/share/xstartup}"
+: "${HEADLESS_MODE:=false}"
 
 # Export variables so they are available to child processes like supervisord
 export DEV_USERNAME DEV_PASSWORD DEV_UID DEV_GID \
        ADMIN_USERNAME ADMIN_PASSWORD ROOT_PASSWORD \
        TTYD_USER TTYD_PASSWORD ENABLE_GOOGLE_ADS_EDITOR \
-       XSTARTUP_SRC
+       XSTARTUP_SRC HEADLESS_MODE
 
 # Initialize system directories
 mkdir -p /var/run/dbus /tmp/.ICE-unix /tmp/.X11-unix

--- a/ubuntu-kde-docker/setup-desktop.sh
+++ b/ubuntu-kde-docker/setup-desktop.sh
@@ -5,6 +5,11 @@ set -euo pipefail
 
 # Icons: 🖥️ 🎨 📁 ✅ ⚠️
 
+if [ "${HEADLESS_MODE:-false}" = "true" ]; then
+    echo "⚠️  Headless mode detected, skipping desktop setup"
+    exit 0
+fi
+
 echo "🖥️  Setting up desktop environment..."
 
 readonly DEV_USERNAME=${DEV_USERNAME:-devuser}

--- a/ubuntu-kde-docker/start-dbus-first.sh
+++ b/ubuntu-kde-docker/start-dbus-first.sh
@@ -4,7 +4,13 @@ set -euo pipefail
 echo "INFO: Robust D-Bus starter script initiated."
 
 # 1. Ensure directory exists with correct permissions
-install -o messagebus -g messagebus -m 755 -d /run/dbus
+# The messagebus user may not exist yet in some minimal images. Create the
+# directory as root first, then adjust ownership if possible to avoid crashes.
+if ! install -o messagebus -g messagebus -m 755 -d /run/dbus 2>/dev/null; then
+  mkdir -p /run/dbus
+  chown messagebus:messagebus /run/dbus 2>/dev/null || true
+  chmod 755 /run/dbus
+fi
 
 # Some base images ship without a machine-id which causes
 # dbus-daemon to exit immediately.  Ensure one exists before

--- a/ubuntu-kde-docker/start-vnc-robust.sh
+++ b/ubuntu-kde-docker/start-vnc-robust.sh
@@ -5,6 +5,11 @@ set -e
 
 echo "🚀 Starting robust VNC server..."
 
+# Ensure X11 socket directory exists and is writable
+if ! install -m 1777 -d /tmp/.X11-unix 2>/dev/null; then
+    echo "⚠️  Unable to prepare /tmp/.X11-unix; X11 applications may fail" >&2
+fi
+
 # Define possible VNC binary locations
 VNC_BINARIES=(
     "/usr/bin/kasmvncserver"
@@ -86,7 +91,13 @@ export PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
 export DISPLAY=${DISPLAY:-:1}
 unset SESSION_MANAGER
 unset DBUS_SESSION_BUS_ADDRESS
-exec dbus-launch --exit-with-session /usr/bin/startplasma-x11
+
+if command -v startplasma-x11 >/dev/null 2>&1; then
+  dbus-launch --exit-with-session startplasma-x11 || xterm
+else
+  echo "startplasma-x11 not found, launching xterm" >&2
+  xterm
+fi
 EOF
         chmod 755 /root/.vnc/xstartup
     fi

--- a/ubuntu-kde-docker/system-validation.sh
+++ b/ubuntu-kde-docker/system-validation.sh
@@ -27,6 +27,11 @@ log_validation() {
     fi
 }
 
+if [ "${HEADLESS_MODE:-false}" = "true" ]; then
+    log_validation "Headless mode detected, skipping system validation" "INFO"
+    exit 0
+fi
+
 # Ensure required utilities exist; if they're missing we log the issue and
 # exit successfully. Missing tools shouldn't cause the container to thrash.
 REQUIRED_CMDS=(pgrep supervisorctl curl)


### PR DESCRIPTION
## Summary
- add `HEADLESS_MODE` flag to skip optional desktop services
- harden D-Bus and X11 setup for container use
- provide KDE fallback to xterm if X11 fails

## Testing
- `npm test` (fails: Missing script: "test")
- `npm run lint` (fails: Cannot find package '@eslint/js')

------
https://chatgpt.com/codex/tasks/task_b_688e8ec22e10832f80480c6e22984136