### PR TITLE
fix: stabilize dbus and kasmvnc startup

### DIFF
--- a/ubuntu-kde-docker/entrypoint.sh
+++ b/ubuntu-kde-docker/entrypoint.sh
@@ -40,6 +40,11 @@ if ! chmod 1777 /tmp/.ICE-unix /tmp/.X11-unix 2>/dev/null; then
   log_warn "/tmp/.X11-unix permissions could not be modified (read-only mount?)"
 fi
 
+# Ensure machine-id exists for stable D-Bus operation
+if [ ! -s /etc/machine-id ]; then
+  dbus-uuidgen --ensure=/etc/machine-id >/dev/null 2>&1 || true
+fi
+
 # Replace default username in polkit rule if different
 if [ -f /etc/polkit-1/rules.d/99-devuser-all.rules ]; then
     sed -i "s/\"devuser\"/\"${DEV_USERNAME}\"/" /etc/polkit-1/rules.d/99-devuser-all.rules

--- a/ubuntu-kde-docker/supervisord.conf
+++ b/ubuntu-kde-docker/supervisord.conf
@@ -58,11 +58,11 @@ priority=40
 autostart=true
 autorestart=true
 stopsignal=TERM
-user=root
+user=%(ENV_DEV_USERNAME)s
 startsecs=10
 startretries=5
 exitcodes=0,1,2
-environment=KASMVNC_PORT="%(ENV_KASMVNC_PORT)s",KASMVNC_VNC_PORT="%(ENV_KASMVNC_VNC_PORT)s",DISPLAY=":1"
+environment=KASMVNC_PORT="%(ENV_KASMVNC_PORT)s",KASMVNC_VNC_PORT="%(ENV_KASMVNC_VNC_PORT)s",DISPLAY=":1",HOME="/home/%(ENV_DEV_USERNAME)s",USER="%(ENV_DEV_USERNAME)s",XDG_RUNTIME_DIR="/run/user/%(ENV_DEV_UID)s"
 stdout_logfile=/var/log/supervisor/kasmvnc.log
 stderr_logfile=/var/log/supervisor/kasmvnc.log
 stdout_logfile_maxbytes=10MB

--- a/ubuntu-kde-docker/xstartup
+++ b/ubuntu-kde-docker/xstartup
@@ -13,5 +13,13 @@ export DISPLAY=${DISPLAY:-:1}
 unset SESSION_MANAGER
 unset DBUS_SESSION_BUS_ADDRESS
 
-# Launch KDE Plasma within a D-Bus session
-exec dbus-launch --exit-with-session /usr/bin/startplasma-x11
+# Run KDE Plasma inside a D-Bus session
+DEV_USERNAME="${DEV_USERNAME:-devuser}"
+DEV_UID="${DEV_UID:-1000}"
+export XDG_RUNTIME_DIR="/run/user/${DEV_UID}"
+
+if [ "$(id -un)" = "$DEV_USERNAME" ]; then
+  exec dbus-launch --exit-with-session /usr/bin/startplasma-x11
+else
+  exec su - "$DEV_USERNAME" -c "export XDG_RUNTIME_DIR=/run/user/${DEV_UID}; dbus-launch --exit-with-session /usr/bin/startplasma-x11"
+fi


### PR DESCRIPTION
## Summary
- ensure /etc/machine-id is created before services start
- run KDE session as dev user and use XDG runtime directories correctly
- launch KasmVNC under dev user with home-based config handling

## Testing
- `bash -n ubuntu-kde-docker/entrypoint.sh`
- `bash -n ubuntu-kde-docker/start-vnc-robust.sh`
- `bash -n ubuntu-kde-docker/xstartup`
- `npm test` *(fails: Missing script "test")*


------
https://chatgpt.com/codex/tasks/task_b_688e94cabb70832fbb4557f5f2c406ce