### PR TITLE
Ensure kasmvnc install works without root and guard audio validation

### DIFF
--- a/ubuntu-kde-docker/audio-validation.sh
+++ b/ubuntu-kde-docker/audio-validation.sh
@@ -2,12 +2,22 @@
 # Audio System Validation Script for Marketing Agency WebTop
 # Validates and repairs audio configuration after container startup
 
-set -e
+set -euo pipefail
 
 DEV_USERNAME="${DEV_USERNAME:-devuser}"
 DEV_UID="${DEV_UID:-1000}"
 
 echo "🔊 Validating audio system configuration..."
+
+# Ensure required commands are present. If any are missing we
+# skip validation rather than failing the supervisor job with a
+# 127 exit code which indicates "command not found".
+for cmd in pactl su; do
+    if ! command -v "$cmd" >/dev/null 2>&1; then
+        echo "⚠️  Required command '$cmd' not found; skipping audio validation." >&2
+        exit 0
+    fi
+done
 
 # Color output functions
 red() { echo -e "\033[31m$*\033[0m"; }

--- a/ubuntu-kde-docker/start-vnc-robust.sh
+++ b/ubuntu-kde-docker/start-vnc-robust.sh
@@ -61,7 +61,13 @@ VNC_BINARY=$(find_vnc_binary || true)
 # If no binary found, try to install KasmVNC on the fly
 if [ -z "$VNC_BINARY" ]; then
     echo "⚠️  No VNC server binary found. Attempting installation..."
-    if /usr/local/bin/setup-kasmvnc.sh >/var/log/kasmvnc-install.log 2>&1; then
+    if command -v sudo >/dev/null 2>&1; then
+        INSTALL_CMD="sudo /usr/local/bin/setup-kasmvnc.sh"
+    else
+        INSTALL_CMD="/usr/local/bin/setup-kasmvnc.sh"
+    fi
+
+    if $INSTALL_CMD >/var/log/kasmvnc-install.log 2>&1; then
         VNC_BINARY=$(find_vnc_binary || true)
     else
         echo "❌ KasmVNC installation failed. Check /var/log/kasmvnc-install.log for details."


### PR DESCRIPTION
## Summary
- Prevent audio-validation script from failing when `pactl` or `su` are missing
- Allow KasmVNC startup script to use sudo for on-demand installation

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_b_688f3838c924832fa5e378bb11968080