### PR TITLE
fix: handle missing services gracefully

### DIFF
--- a/ubuntu-kde-docker/Dockerfile
+++ b/ubuntu-kde-docker/Dockerfile
@@ -178,6 +178,7 @@ COPY test-desktop-audio.sh /usr/local/bin/test-desktop-audio.sh
 COPY audio-validation.sh /usr/local/bin/audio-validation.sh
 COPY system-validation.sh /usr/local/bin/system-validation.sh
 COPY audio-monitor.sh /usr/local/bin/audio-monitor.sh
+COPY start-pulseaudio.sh /usr/local/bin/start-pulseaudio.sh
 COPY health-check.sh /usr/local/bin/health-check.sh
 COPY fix-permissions.sh /usr/local/bin/fix-permissions.sh
 COPY test-polkit.sh /usr/local/bin/test-polkit.sh
@@ -191,6 +192,7 @@ RUN chmod +x /usr/local/bin/setup-*.sh \
     /usr/local/bin/test-desktop-audio.sh \
     /usr/local/bin/audio-monitor.sh \
     /usr/local/bin/audio-validation.sh \
+    /usr/local/bin/start-pulseaudio.sh \
     /usr/local/bin/health-check.sh \
     /usr/local/bin/fix-permissions.sh \
     /usr/local/bin/test-polkit.sh \

--- a/ubuntu-kde-docker/start-pulseaudio.sh
+++ b/ubuntu-kde-docker/start-pulseaudio.sh
@@ -1,0 +1,20 @@
+#!/bin/bash
+set -euo pipefail
+
+DEV_USERNAME="${DEV_USERNAME:-devuser}"
+DEV_UID="${DEV_UID:-1000}"
+
+if ! command -v pulseaudio >/dev/null 2>&1; then
+  echo "⚠️ pulseaudio not found; skipping startup"
+  exit 0
+fi
+
+export XDG_RUNTIME_DIR="/run/user/${DEV_UID}"
+export PULSE_RUNTIME_PATH="${XDG_RUNTIME_DIR}/pulse"
+mkdir -p "$PULSE_RUNTIME_PATH"
+if id "$DEV_USERNAME" >/dev/null 2>&1; then
+  chown "$DEV_USERNAME:$DEV_USERNAME" "$XDG_RUNTIME_DIR" "$PULSE_RUNTIME_PATH" || true
+fi
+
+/usr/local/bin/wait-for-dbus.sh
+exec /usr/bin/pulseaudio --daemonize=no --disallow-exit --exit-idle-time=-1 --system=false --file="/home/${DEV_USERNAME}/.config/pulse/default.pa"

--- a/ubuntu-kde-docker/start-vnc-robust.sh
+++ b/ubuntu-kde-docker/start-vnc-robust.sh
@@ -13,9 +13,8 @@ echo "🚀 Starting KasmVNC server..."
 VNC_BINARY="/usr/bin/kasmvncserver"
 
 if [ ! -x "$VNC_BINARY" ]; then
-    echo "❌ KasmVNC binary not found at $VNC_BINARY!"
-    echo "Please ensure the Docker image was built correctly and the KasmVNC .deb package was installed."
-    exit 127
+    echo "❌ KasmVNC binary not found at $VNC_BINARY! Skipping start."
+    exit 0
 fi
 
 # 1. Wait for the D-Bus socket to be created

--- a/ubuntu-kde-docker/supervisord.conf
+++ b/ubuntu-kde-docker/supervisord.conf
@@ -32,7 +32,7 @@ stdout_logfile=/var/log/supervisor/polkitd.log
 stderr_logfile=/var/log/supervisor/polkitd.log
 
 [program:accountsservice]
-command=/usr/lib/accountsservice/accounts-daemon
+command=/usr/libexec/accounts-daemon
 priority=15
 autostart=true
 autorestart=true
@@ -44,7 +44,7 @@ stdout_logfile=/var/log/supervisor/accountsservice.log
 stderr_logfile=/var/log/supervisor/accountsservice.log
 
 [program:pulseaudio]
-command=/bin/bash -c "export XDG_RUNTIME_DIR=/run/user/%(ENV_DEV_UID)s; /usr/local/bin/wait-for-dbus.sh && exec /usr/bin/pulseaudio --daemonize=no --disallow-exit --exit-idle-time=-1 --system=false --file=/home/%(ENV_DEV_USERNAME)s/.config/pulse/default.pa"
+command=/usr/local/bin/start-pulseaudio.sh
 priority=20
 autostart=true
 autorestart=true


### PR DESCRIPTION
## Summary
- ensure pulseaudio service only runs when available
- fix accountsservice path for Ubuntu 24.04
- skip KasmVNC startup if the binary is missing

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_b_688f5801e4bc832f864501cae9e3dfea