### PR TITLE
Fix D-Bus wait script installation

### DIFF
--- a/ubuntu-kde-docker/Dockerfile
+++ b/ubuntu-kde-docker/Dockerfile
@@ -170,6 +170,7 @@ COPY setup-video-editing.sh /usr/local/bin/setup-video-editing.sh
 COPY setup-ttyd.sh /usr/local/bin/setup-ttyd.sh
 COPY ttyd-wrapper.sh /usr/local/bin/ttyd-wrapper.sh
 COPY ./start-dbus-first.sh /usr/local/bin/start-dbus-first.sh
+COPY wait-for-dbus.sh /usr/local/bin/wait-for-dbus.sh
 COPY start-vnc-robust.sh /usr/local/bin/start-vnc-robust.sh
 COPY check-vnc-health.sh /usr/local/bin/check-vnc-health.sh
 COPY enhanced-health-check.sh /usr/local/bin/enhanced-health-check.sh
@@ -185,6 +186,7 @@ COPY test-polkit.sh /usr/local/bin/test-polkit.sh
 COPY monitor-services.sh /usr/local/bin/monitor-services.sh
 RUN chmod +x /usr/local/bin/setup-*.sh \
     /usr/local/bin/start-dbus-first.sh \
+    /usr/local/bin/wait-for-dbus.sh \
     /usr/local/bin/start-vnc-robust.sh \
     /usr/local/bin/check-vnc-health.sh \
     /usr/local/bin/enhanced-health-check.sh \


### PR DESCRIPTION
## Summary
- Copy `wait-for-dbus.sh` into the image and mark it executable so dependent services start correctly.

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_b_688f5deda5c8832fa81a7324add9b5af