### PR TITLE
fix: stabilize vnc and audio monitoring

### DIFF
--- a/ubuntu-kde-docker/audio-monitor.sh
+++ b/ubuntu-kde-docker/audio-monitor.sh
@@ -116,7 +116,7 @@ generate_audio_status() {
     fi
     
     # Check KDE integration
-    check_kde_audio
+    check_kde_audio || true
     
     # Check if test script is available
     if [ -f "/usr/local/bin/test-desktop-audio.sh" ]; then

--- a/ubuntu-kde-docker/start-vnc-robust.sh
+++ b/ubuntu-kde-docker/start-vnc-robust.sh
@@ -3,7 +3,7 @@ set -e
 
 # Capture all output for troubleshooting while still emitting to the
 # supervisord log. This helps diagnose early startup failures.
-LOG_FILE="/var/log/kasmvnc.log"
+LOG_FILE="$HOME/kasmvnc.log"
 mkdir -p "$(dirname "$LOG_FILE")"
 exec > >(tee -a "$LOG_FILE") 2>&1
 


### PR DESCRIPTION
## Summary
- ensure VNC startup script logs in user home to avoid permission errors
- prevent audio monitor from exiting when KDE audio components are missing

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm ci`
- `npm run lint`
- `bash -n ubuntu-kde-docker/start-vnc-robust.sh`
- `bash -n ubuntu-kde-docker/audio-monitor.sh`
- `shellcheck ubuntu-kde-docker/start-vnc-robust.sh ubuntu-kde-docker/audio-monitor.sh`


------
https://chatgpt.com/codex/tasks/task_b_688f6233621c832fb00cde3f0ce25136