### PR TITLE
fix: fallback to tmp for KasmVNC logs

### DIFF
--- a/ubuntu-kde-docker/start-vnc-robust.sh
+++ b/ubuntu-kde-docker/start-vnc-robust.sh
@@ -3,8 +3,15 @@ set -e
 
 # Capture all output for troubleshooting while still emitting to the
 # supervisord log. This helps diagnose early startup failures.
-LOG_FILE="$HOME/kasmvnc.log"
-mkdir -p "$(dirname "$LOG_FILE")"
+# If the user's home directory is not writable (e.g. due to leftover
+# root-owned files), fall back to using /tmp so the script does not
+# terminate before starting the VNC server.
+LOG_DIR="${HOME:-/tmp}"
+if ! mkdir -p "$LOG_DIR" 2>/dev/null; then
+    LOG_DIR="/tmp"
+    mkdir -p "$LOG_DIR"
+fi
+LOG_FILE="$LOG_DIR/kasmvnc.log"
 exec > >(tee -a "$LOG_FILE") 2>&1
 
 echo "🚀 Starting KasmVNC server..."


### PR DESCRIPTION
## Summary
- avoid KasmVNC startup failure when the home directory isn't writable by falling back to /tmp for log output

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_b_688f7355c55c832fb3922f79790c3fea