### PR TITLE
fix: remove read-only X11 socket mount

### DIFF
--- a/ubuntu-kde-docker/docker-compose.dev.yml
+++ b/ubuntu-kde-docker/docker-compose.dev.yml
@@ -29,7 +29,6 @@ services:
     volumes:
       - ./dev_config:/config
       - ./logs:/var/log/supervisor
-      - /tmp/.X11-unix:/tmp/.X11-unix:rw
       - /lib/modules:/lib/modules:ro
       - /dev:/dev:rw
       - ./dbus_session:/run/user/1000

--- a/ubuntu-kde-docker/docker-compose.yml
+++ b/ubuntu-kde-docker/docker-compose.yml
@@ -30,7 +30,6 @@ services:
     volumes:
       - ${DATA_ROOT}/default/config:/config
       - ${DATA_ROOT}/default/logs:/var/log/supervisor
-      - /tmp/.X11-unix:/tmp/.X11-unix:ro  # Read-only for X11 socket
       - /lib/modules:/lib/modules:ro      # Kernel modules access
       - /dev:/dev:rw                      # Device access for Android
       - ${DATA_ROOT}/default/dbus_session:/run/user/1000

--- a/ubuntu-kde-docker/lib/container-manager.sh
+++ b/ubuntu-kde-docker/lib/container-manager.sh
@@ -100,7 +100,6 @@ services:
       - ${DATA_ROOT}/${container_name}/logs:/var/log/supervisor
       - ${DATA_ROOT}/${container_name}/dbus_session:/run/user/1000
       - shared_resources:/shared:ro
-      - /tmp/.X11-unix:/tmp/.X11-unix:ro
     devices:
       - /dev/snd:/dev/snd
     tmpfs:


### PR DESCRIPTION
## Summary
- remove host `/tmp/.X11-unix` bind mount from docker-compose files
- update container manager to stop injecting read-only X11 socket mount

## Testing
- `bash -n ubuntu-kde-docker/lib/container-manager.sh`
- `python3 - <<'PY'
import yaml, sys
import json
for file in ['ubuntu-kde-docker/docker-compose.yml','ubuntu-kde-docker/docker-compose.dev.yml']:
    with open(file) as f:
        yaml.safe_load(f)
print('YAML_OK')
PY`
- `npm test` *(fails: Missing script "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_b_688f7796c2ec832f88aa6e2cb9f0fa7c