### PR TITLE
fix: stabilize pulseaudio startup

### DIFF
--- a/ubuntu-kde-docker/entrypoint.sh
+++ b/ubuntu-kde-docker/entrypoint.sh
@@ -192,7 +192,12 @@ if [ -f "/usr/local/bin/setup-audio.sh" ]; then
         /usr/local/bin/fix-audio-startup.sh
         log_info "Audio startup configuration completed"
     fi
-    
+
+    # Warn if host audio devices are not available
+    if [ ! -d /dev/snd ]; then
+        log_warn "/dev/snd device not found. Audio may not function; run container with --device /dev/snd"
+    fi
+
     # Schedule audio validation after services start
     if [ -f "/usr/local/bin/audio-validation.sh" ]; then
         chmod +x /usr/local/bin/audio-validation.sh

--- a/ubuntu-kde-docker/setup-audio.sh
+++ b/ubuntu-kde-docker/setup-audio.sh
@@ -48,13 +48,7 @@ if [ "$IS_RUNTIME" = true ]; then
     cat <<EOF > "/home/${DEV_USERNAME}/.config/pulse/default.pa"
 #!/usr/bin/pulseaudio -nF
 
-# Core modules
-load-module module-device-restore
-load-module module-stream-restore
-load-module module-card-restore
-load-module module-augment-properties
-
-# Local and TCP protocols
+# Core protocols with anonymous authentication
 load-module module-native-protocol-unix auth-anonymous=1 socket=/run/user/${DEV_UID}/pulse/native
 load-module module-native-protocol-tcp auth-anonymous=1 port=4713 listen=0.0.0.0
 
@@ -63,19 +57,9 @@ load-module module-null-sink sink_name=virtual_speaker sink_properties=device.de
 load-module module-null-sink sink_name=virtual_microphone sink_properties=device.description="Virtual_Marketing_Microphone"
 load-module module-virtual-source source_name=virtual_mic_source master=virtual_microphone.monitor source_properties=device.description="Virtual_Marketing_Mic_Source"
 
-# Essential modules
-load-module module-default-device-restore
-load-module module-rescue-streams
-load-module module-always-sink
-load-module module-suspend-on-idle
-load-module module-switch-on-port-available
-load-module module-switch-on-connect
-
-# Default devices
+# Defaults
 set-default-sink virtual_speaker
 set-default-source virtual_mic_source
-
-# Volume levels
 set-sink-volume virtual_speaker 32768
 set-sink-volume virtual_microphone 32768
 

--- a/ubuntu-kde-docker/start-pulseaudio.sh
+++ b/ubuntu-kde-docker/start-pulseaudio.sh
@@ -9,12 +9,29 @@ if ! command -v pulseaudio >/dev/null 2>&1; then
   exit 0
 fi
 
-export XDG_RUNTIME_DIR="/run/user/${DEV_UID}"
-export PULSE_RUNTIME_PATH="${XDG_RUNTIME_DIR}/pulse"
+XDG_RUNTIME_DIR="/run/user/${DEV_UID}"
+PULSE_RUNTIME_PATH="${XDG_RUNTIME_DIR}/pulse"
+
+# Ensure runtime directory exists and has correct permissions
 mkdir -p "$PULSE_RUNTIME_PATH"
-if id "$DEV_USERNAME" >/dev/null 2>&1; then
-  chown "$DEV_USERNAME:$DEV_USERNAME" "$XDG_RUNTIME_DIR" "$PULSE_RUNTIME_PATH" || true
+chown -R "${DEV_UID}:${DEV_UID}" "$XDG_RUNTIME_DIR"
+chmod 700 "$XDG_RUNTIME_DIR"
+
+# Warn if audio devices are missing
+if [ ! -d /dev/snd ]; then
+  echo "⚠️ /dev/snd not found; audio devices may be unavailable. Did you run the container with --device /dev/snd?"
 fi
 
-/usr/local/bin/wait-for-dbus.sh
-exec /usr/bin/pulseaudio --daemonize=no --disallow-exit --exit-idle-time=-1 --system=false --file="/home/${DEV_USERNAME}/.config/pulse/default.pa"
+# Wait for D-Bus if helper script is available
+if [ -x /usr/local/bin/wait-for-dbus.sh ]; then
+  /usr/local/bin/wait-for-dbus.sh
+fi
+
+# Run PulseAudio as the development user with the proper environment
+exec runuser -u "$DEV_USERNAME" -- env \
+  HOME="/home/${DEV_USERNAME}" \
+  USER="$DEV_USERNAME" \
+  XDG_RUNTIME_DIR="$XDG_RUNTIME_DIR" \
+  PULSE_RUNTIME_PATH="$PULSE_RUNTIME_PATH" \
+  pulseaudio --daemonize=no --disallow-exit --exit-idle-time=-1 --system=false \
+  --file="/home/${DEV_USERNAME}/.config/pulse/default.pa"

--- a/ubuntu-kde-docker/supervisord.conf
+++ b/ubuntu-kde-docker/supervisord.conf
@@ -48,8 +48,7 @@ command=/usr/local/bin/start-pulseaudio.sh
 priority=20
 autostart=true
 autorestart=true
-user=%(ENV_DEV_USERNAME)s
-environment=HOME=/home/%(ENV_DEV_USERNAME)s,USER=%(ENV_DEV_USERNAME)s,XDG_RUNTIME_DIR=/run/user/%(ENV_DEV_UID)s,PULSE_RUNTIME_PATH=/run/user/%(ENV_DEV_UID)s/pulse,DEV_USERNAME=%(ENV_DEV_USERNAME)s,DEV_UID=%(ENV_DEV_UID)s
+environment=DEV_USERNAME=%(ENV_DEV_USERNAME)s,DEV_UID=%(ENV_DEV_UID)s
 startretries=5
 startsecs=10
 stopwaitsecs=5


### PR DESCRIPTION
## Summary
- ensure PulseAudio runtime directory exists with correct ownership and warn when /dev/snd is missing
- run PulseAudio via `runuser` and adjust supervisor configuration
- streamline PulseAudio default configuration to avoid obsolete or duplicate modules

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: Cannot find package '@eslint/js' imported from eslint.config.js)*


------
https://chatgpt.com/codex/tasks/task_b_688fc044793c832f98e9a9336467cdb3