### PR TITLE
fix: resolve pulseaudio startup uid detection

### DIFF
--- a/ubuntu-kde-docker/setup-audio.sh
+++ b/ubuntu-kde-docker/setup-audio.sh
@@ -9,6 +9,7 @@ echo "🔊 Setting up audio system..."
 # Determine if user exists to handle build vs runtime
 if id "$DEV_USERNAME" >/dev/null 2>&1; then
     IS_RUNTIME=true
+    DEV_UID="$(id -u "$DEV_USERNAME")"
     echo "🔧 Runtime mode: applying user configuration"
 else
     IS_RUNTIME=false

--- a/ubuntu-kde-docker/start-pulseaudio.sh
+++ b/ubuntu-kde-docker/start-pulseaudio.sh
@@ -2,7 +2,11 @@
 set -euo pipefail
 
 DEV_USERNAME="${DEV_USERNAME:-devuser}"
-DEV_UID="${DEV_UID:-1000}"
+if id "$DEV_USERNAME" >/dev/null 2>&1; then
+  DEV_UID="$(id -u "$DEV_USERNAME")"
+else
+  DEV_UID="${DEV_UID:-1000}"
+fi
 
 if ! command -v pulseaudio >/dev/null 2>&1; then
   echo "⚠️ pulseaudio not found; skipping startup"


### PR DESCRIPTION
## Summary
- determine devuser UID dynamically when configuring audio setup
- reuse devuser UID for pulseaudio startup rather than assuming 1000

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint` *(fails: Cannot find package '@eslint/js')*


------
https://chatgpt.com/codex/tasks/task_b_688fcd26045c832fb6f9a12b65566900