### PR TITLE
fix(pulseaudio): Remove erroneous shebang from default.pa

### DIFF
--- a/ubuntu-kde-docker/setup-audio.sh
+++ b/ubuntu-kde-docker/setup-audio.sh
@@ -47,8 +47,6 @@ EOF
 if [ "$IS_RUNTIME" = true ]; then
     mkdir -p "/home/${DEV_USERNAME}/.config/pulse"
     cat <<EOF > "/home/${DEV_USERNAME}/.config/pulse/default.pa"
-#!/usr/bin/pulseaudio -nF
-
 # Core protocols with anonymous authentication
 load-module module-native-protocol-unix auth-anonymous=1 socket=/run/user/${DEV_UID}/pulse/native
 load-module module-native-protocol-tcp auth-anonymous=1 port=4713 listen=0.0.0.0


### PR DESCRIPTION
The `setup-audio.sh` script was creating a `default.pa` file with a `#!/usr/bin/pulseaudio -nF` shebang line. This is incorrect for a PulseAudio configuration file, which is parsed, not executed.

This incorrect line was causing PulseAudio to fail to start, leading to a fatal state in supervisord. Removing the line allows the configuration to be parsed correctly, resolving the startup issue.