### PR TITLE
Ensure audio scripts copied and start D-Bus early

### DIFF
--- a/ubuntu-kde-docker/Dockerfile
+++ b/ubuntu-kde-docker/Dockerfile
@@ -163,6 +163,8 @@ COPY audio-monitor.sh /usr/local/bin/audio-monitor.sh
 COPY health-check.sh /usr/local/bin/health-check.sh
 COPY fix-permissions.sh /usr/local/bin/fix-permissions.sh
 COPY test-polkit.sh /usr/local/bin/test-polkit.sh
+COPY create-virtual-audio-devices.sh /usr/local/bin/create-virtual-audio-devices.sh
+COPY setup-universal-audio.sh /usr/local/bin/setup-universal-audio.sh
 RUN chmod +x /usr/local/bin/setup-*.sh \
     /usr/local/bin/service-health.sh \
     /usr/local/bin/test-desktop-audio.sh \
@@ -171,7 +173,8 @@ RUN chmod +x /usr/local/bin/setup-*.sh \
     /usr/local/bin/health-check.sh \
     /usr/local/bin/fix-permissions.sh \
     /usr/local/bin/test-polkit.sh \
-    /usr/local/bin/fix-audio-startup.sh
+    /usr/local/bin/fix-audio-startup.sh \
+    /usr/local/bin/create-virtual-audio-devices.sh
 
 # Initialize audio system during build
 RUN /usr/local/bin/setup-audio.sh && \

--- a/ubuntu-kde-docker/entrypoint.sh
+++ b/ubuntu-kde-docker/entrypoint.sh
@@ -28,7 +28,7 @@ log_warn() {
 }
 
 # Initialize system directories
-mkdir -p /var/run/dbus /run/user/${DEV_UID} /tmp/.ICE-unix /tmp/.X11-unix
+mkdir -p /var/run/dbus "/run/user/${DEV_UID}" /tmp/.ICE-unix /tmp/.X11-unix
 # /tmp/.X11-unix may be mounted read-only by the host. Avoid failing if chmod
 # cannot modify permissions.
 chmod 1777 /tmp/.ICE-unix /tmp/.X11-unix 2>/dev/null || \
@@ -143,6 +143,11 @@ export XDG_RUNTIME_DIR="/run/user/${DEV_UID}"
 echo "🔧 Preparing D-Bus directories..."
 mkdir -p /run/dbus
 echo "✅ D-Bus directories prepared"
+
+# Ensure system D-Bus is running before making D-Bus calls
+if ! pgrep -x dbus-daemon >/dev/null 2>&1; then
+    dbus-daemon --system --fork 2>/dev/null || true
+fi
 
 # Set up audio system before other services
 log_info "Setting up audio system..."

--- a/ubuntu-kde-docker/setup-universal-audio.sh
+++ b/ubuntu-kde-docker/setup-universal-audio.sh
@@ -13,7 +13,7 @@ check_novnc_ready() {
     local count=0
     
     while [ $count -lt $timeout ]; do
-        if [ -d "$NOVNC_DIR" ] && ([ -f "$NOVNC_DIR/vnc.html" ] || [ -f "$NOVNC_DIR/index.html" ]); then
+        if [ -d "$NOVNC_DIR" ] && { [ -f "$NOVNC_DIR/vnc.html" ] || [ -f "$NOVNC_DIR/index.html" ]; }; then
             echo "✅ noVNC installation detected"
             return 0
         fi


### PR DESCRIPTION
## Summary
- Install missing audio setup scripts in the image and make them executable
- Start system D-Bus before executing D-Bus operations to avoid connection errors
- Clean up shell script style for universal audio setup

## Testing
- `shellcheck -f json ubuntu-kde-docker/entrypoint.sh ubuntu-kde-docker/create-virtual-audio-devices.sh ubuntu-kde-docker/setup-universal-audio.sh`
- `bash -n ubuntu-kde-docker/entrypoint.sh ubuntu-kde-docker/setup-universal-audio.sh ubuntu-kde-docker/create-virtual-audio-devices.sh`
- `npm install --no-audit --no-fund`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_b_688ff2ec9f44832fa18e898f50f0a3e0