### PR TITLE
Enable 32-bit Wine support

### DIFF
--- a/ubuntu-kde-docker/Dockerfile
+++ b/ubuntu-kde-docker/Dockerfile
@@ -2,6 +2,9 @@ FROM ubuntu:24.04
 
 ENV DEBIAN_FRONTEND=noninteractive
 
+# Enable 32-bit architecture for Wine support
+RUN dpkg --add-architecture i386
+
 # Install all required packages and lightweight fallback WM
 RUN apt-get update && apt-get install -y \
     sudo wget curl gnupg2 apt-transport-https software-properties-common \
@@ -24,7 +27,7 @@ RUN apt-get update && apt-get install -y \
     # Docker and Container Tools
     docker.io docker-compose \
     # Wine for Windows applications
-    wine winetricks playonlinux winbind \
+    wine winetricks playonlinux winbind wine32:i386 libwine:i386 cabextract fonts-liberation \
     # Android/Waydroid support
     python3-requests-unixsocket \
     lxc-utils dbus-user-session systemd-container \

--- a/ubuntu-kde-docker/setup-wine.sh
+++ b/ubuntu-kde-docker/setup-wine.sh
@@ -6,11 +6,23 @@ DEV_HOME="/home/${DEV_USERNAME}"
 
 echo "🍷 Setting up Wine for Windows applications..."
 
-# Initialize Wine prefix with proper architecture
+# Clean up any existing Wine state
+rm -rf "${DEV_HOME}/.wine"
+rm -f /tmp/.X*-lock
+killall -q Xvfb wineserver wine 2>/dev/null || true
+
+# Initialize Wine prefix with 32-bit architecture
 export WINEPREFIX="${DEV_HOME}/.wine"
-export WINEARCH="win64"
+export WINEARCH="win32"
 export WINEDLLOVERRIDES="mscoree,mshtml="
 mkdir -p "$WINEPREFIX"
+
+# Start a virtual display if needed
+if ! pgrep Xvfb >/dev/null; then
+    Xvfb :99 -screen 0 1024x768x16 &
+    sleep 2
+fi
+export DISPLAY=:99
 
 # Ensure Wine prefix is properly owned
 mkdir -p "$WINEPREFIX"
@@ -19,9 +31,9 @@ chown -R "${DEV_USERNAME}:${DEV_USERNAME}" "$WINEPREFIX"
 # Set up Wine as the dev user
 sudo -u "$DEV_USERNAME" bash << 'WINE_SETUP'
 export WINEPREFIX="/home/devuser/.wine"
-export WINEARCH="win64"
+export WINEARCH="win32"
 export WINEDLLOVERRIDES="mscoree,mshtml="
-export DISPLAY=:1
+export DISPLAY=:99
 
 # Initialize Wine with no GUI prompts
 echo "🔧 Initializing Wine prefix..."
@@ -75,3 +87,4 @@ cp "${DEV_HOME}/.local/share/applications/wine-"*.desktop "${DEV_HOME}/Desktop/W
 chown -R "${DEV_USERNAME}:${DEV_USERNAME}" "${DEV_HOME}"
 
 echo "✅ Wine setup complete"
+


### PR DESCRIPTION
## Summary
- enable i386 multiarch and install 32-bit Wine packages
- clean and initialize 32-bit Wine prefix with Xvfb display

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm install`
- `npm run lint`
- `bash -n ubuntu-kde-docker/setup-wine.sh`


------
https://chatgpt.com/codex/tasks/task_b_68904505b6fc832fa1747ede0d09b599