### PR TITLE
Fix audio setup for non-default user IDs

### DIFF
--- a/ubuntu-kde-docker/README_AUDIO.md
+++ b/ubuntu-kde-docker/README_AUDIO.md
@@ -10,6 +10,28 @@ This WebTop includes a comprehensive audio system with web-based streaming capab
 - **KDE Integration**: Full audio support within KDE Plasma desktop
 - **Automatic Recovery**: Self-healing audio system with validation and monitoring
 
+## Host Setup
+
+The container relies on an ALSA loopback device provided by the host. Before
+starting the WebTop container, make sure the module is loaded:
+
+```bash
+sudo modprobe snd-aloop
+echo snd-aloop | sudo tee -a /etc/modules
+```
+
+For PulseAudio to function, mount a user runtime directory from the host and
+expose it to the container. Replace `<uid>` with the ID used for the container
+user:
+
+```bash
+-v /run/user/<uid>:/run/user/<uid> \
+-e XDG_RUNTIME_DIR=/run/user/<uid>
+```
+
+These steps ensure the audio system has the necessary devices and runtime
+environment when the container starts.
+
 ## How It Works
 
 ### Audio Architecture

--- a/ubuntu-kde-docker/create-virtual-audio-devices.sh
+++ b/ubuntu-kde-docker/create-virtual-audio-devices.sh
@@ -5,7 +5,9 @@
 set -e
 
 DEV_USERNAME="${DEV_USERNAME:-devuser}"
-DEV_UID="${DEV_UID:-1000}"
+# Determine UID dynamically so audio setup works when the container user has a
+# non-default UID (e.g. when mapped to host user IDs).
+DEV_UID="${DEV_UID:-$(id -u "$DEV_USERNAME" 2>/dev/null || echo 1000)}"
 
 echo "🔊 Creating persistent virtual audio devices..."
 

--- a/ubuntu-kde-docker/fix-audio-startup.sh
+++ b/ubuntu-kde-docker/fix-audio-startup.sh
@@ -5,7 +5,8 @@
 set -euo pipefail
 
 DEV_USERNAME="${DEV_USERNAME:-devuser}"
-DEV_UID="${DEV_UID:-1000}"
+# Determine the correct UID at runtime. Fall back to 1000 if the user doesn't exist yet
+DEV_UID="${DEV_UID:-$(id -u "$DEV_USERNAME" 2>/dev/null || echo 1000)}"
 
 echo "🔧 Fixing audio system startup configuration..."
 

--- a/ubuntu-kde-docker/setup-anbox.sh
+++ b/ubuntu-kde-docker/setup-anbox.sh
@@ -3,6 +3,8 @@ set -euo pipefail
 
 DEV_USERNAME="${DEV_USERNAME:-devuser}"
 DEV_HOME="/home/${DEV_USERNAME}"
+# Resolve the UID for the runtime directory
+DEV_UID="${DEV_UID:-$(id -u "$DEV_USERNAME" 2>/dev/null || echo 1000)}"
 
 # Logging function
 log_info() {
@@ -58,7 +60,7 @@ cat > "${DEV_HOME}/.config/anbox/config" << 'EOF'
 [core]
 use_system_dbus=false
 data_path=/home/devuser/.local/share/anbox
-socket_path=/run/user/1000/anbox_bridge
+socket_path=/run/user/${DEV_UID}/anbox_bridge
 
 [graphics]
 egl_driver=swiftshader
@@ -73,7 +75,7 @@ mkdir -p "${DEV_HOME}/.local/bin"
 cat > "${DEV_HOME}/.local/bin/anbox-start" << 'EOF'
 #!/bin/bash
 export ANBOX_LOG_LEVEL=info
-export XDG_RUNTIME_DIR="/run/user/1000"
+export XDG_RUNTIME_DIR="/run/user/${DEV_UID}"
 
 # Start Anbox session manager
 anbox session-manager &

--- a/ubuntu-kde-docker/setup-waydroid.sh
+++ b/ubuntu-kde-docker/setup-waydroid.sh
@@ -3,6 +3,8 @@ set -euo pipefail
 
 DEV_USERNAME="${DEV_USERNAME:-devuser}"
 DEV_HOME="/home/${DEV_USERNAME}"
+# Determine the UID of the development user for runtime directory paths
+DEV_UID="${DEV_UID:-$(id -u "$DEV_USERNAME" 2>/dev/null || echo 1000)}"
 
 # Logging function
 log_info() {
@@ -42,9 +44,9 @@ arch=x86_64
 images_path=/home/devuser/.local/share/waydroid/images
 vendor_type=MAINLINE
 system_type=VANILLA
-xdg_runtime_dir=/run/user/1000
+xdg_runtime_dir=/run/user/${DEV_UID}
 wayland_display=wayland-0
-pulse_server=unix:/run/user/1000/pulse/native
+pulse_server=unix:/run/user/${DEV_UID}/pulse/native
 
 [session]
 user_manager=true
@@ -55,7 +57,7 @@ EOF
 
     # Try to initialize Waydroid with container-specific settings
     export WAYDROID_LOG=true
-    export XDG_RUNTIME_DIR="/run/user/1000"
+    export XDG_RUNTIME_DIR="/run/user/${DEV_UID}"
     export WAYLAND_DISPLAY="wayland-0"
     
     # Initialize without hardware requirements


### PR DESCRIPTION
## Summary
- Resolve developer UID dynamically in audio setup scripts to avoid hard-coded `/run/user/1000` paths
- Ensure Waydroid and Anbox scripts respect the container user's runtime directory
- Document host requirements for loading `snd-aloop` and mounting the runtime directory

## Testing
- `npm test` (fails: Missing script "test")
- `npm run lint` (fails: Cannot find package '@eslint/js')


------
https://chatgpt.com/codex/tasks/task_b_68906dc94380832fbbe1aa9af282935c