### PR TITLE
fix: use secure WebSocket protocol for audio

### DIFF
--- a/ubuntu-kde-docker/integrate-audio-ui.sh
+++ b/ubuntu-kde-docker/integrate-audio-ui.sh
@@ -361,12 +361,13 @@ cat > "$NOVNC_DIR/vnc_audio.html" << 'EOF'
                         this.setVolume(savedVolume);
                     }
                     
-                    // Try multiple connection methods with fallback
+                    // Determine the appropriate WebSocket protocol based on the page context
+                    const wsProtocol = window.location.protocol === 'https:' ? 'wss' : 'ws';
+
+                    // Try multiple connection methods with fallback using the matched protocol
                     const connectionMethods = [
-                        () => this.connectWebSocket(`ws://${window.location.hostname}:8080`),
-                        () => this.connectWebSocket(`wss://${window.location.hostname}:8080`),
-                        () => this.connectWebSocket(`ws://${window.location.host}/audio-bridge`),
-                        () => this.connectWebSocket(`wss://${window.location.host}/audio-bridge`)
+                        () => this.connectWebSocket(`${wsProtocol}://${window.location.hostname}:8080`),
+                        () => this.connectWebSocket(`${wsProtocol}://${window.location.host}/audio-bridge`)
                     ];
                     
                     for (const method of connectionMethods) {

--- a/ubuntu-kde-docker/universal-audio.js
+++ b/ubuntu-kde-docker/universal-audio.js
@@ -397,11 +397,10 @@
         }
 
         async attemptConnection() {
+            const wsProtocol = window.location.protocol === 'https:' ? 'wss' : 'ws';
             const wsUrls = [
-                `ws://${window.location.hostname}:8080`,
-                `wss://${window.location.hostname}:8080`,
-                `ws://${window.location.host}/audio-bridge`,
-                `wss://${window.location.host}/audio-bridge`
+                `${wsProtocol}://${window.location.hostname}:8080`,
+                `${wsProtocol}://${window.location.host}/audio-bridge`
             ];
 
             for (const wsUrl of wsUrls) {


### PR DESCRIPTION
## Summary
- select WebSocket protocol based on page context to avoid mixed content errors

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_b_68907579b648832faaf45d4c6af551f7