### PR TITLE
Fix startup script warnings and redundancies

### DIFF
--- a/ubuntu-kde-docker/entrypoint.sh
+++ b/ubuntu-kde-docker/entrypoint.sh
@@ -59,17 +59,7 @@ EOF
 
 # Initialize system directories
 mkdir -p /var/run/dbus /tmp/.ICE-unix /tmp/.X11-unix
-# /tmp/.X11-unix may be mounted read-only by the host. Avoid failing if chmod
-# cannot modify permissions.
-chmod 1777 /tmp/.ICE-unix /tmp/.X11-unix 2>/dev/null || \
-  echo "⚠️  Warning: unable to set permissions on /tmp/.X11-unix"
-if [ ! -w /tmp/.X11-unix ]; then
-  log_warn "/tmp/.X11-unix is not writable; attempting to recreate"
-  rm -rf /tmp/.X11-unix 2>/dev/null || true
-  mkdir -p /tmp/.X11-unix
-  chmod 1777 /tmp/.X11-unix 2>/dev/null || \
-    log_warn "Failed to set permissions on /tmp/.X11-unix; Xvfb may not work"
-fi
+chmod 1777 /tmp/.ICE-unix
 
 # Replace default username in polkit rule if different
 if [ -f /etc/polkit-1/rules.d/99-devuser-all.rules ]; then
@@ -221,14 +211,7 @@ else
     echo "⚠️  Desktop audio integration script not found"
 fi
 
-# Set up Wine for Windows applications
-log_info "Setting up Wine for Windows applications..."
-if [ -f "/usr/local/bin/setup-wine.sh" ]; then
-    /usr/local/bin/setup-wine.sh
-    echo "✅ Wine setup completed"
-else
-    echo "⚠️  Wine setup script not found"
-fi
+# Wine setup is handled later in the script.
 
 # Generate SSH host keys if they don't exist
 log_info "Setting up SSH host keys..."

--- a/ubuntu-kde-docker/setup-waydroid.sh
+++ b/ubuntu-kde-docker/setup-waydroid.sh
@@ -79,7 +79,7 @@ log_info "Checking for Android subsystem requirements..."
 
 # Waydroid requires binder_linux and ashmem_linux kernel modules on the host.
 if ! lsmod | grep -q "binder_linux" || ! lsmod | grep -q "ashmem_linux"; then
-    log_error "Android subsystem setup failed: Missing required kernel modules."
+    log_warn "Android subsystem setup failed: Missing required kernel modules."
     log_warn "The host system is missing 'binder_linux' and/or 'ashmem_linux' kernel modules."
     log_warn "These modules must be loaded on the Docker host to enable Android support."
     log_warn "Waydroid installation will be skipped."


### PR DESCRIPTION
This commit addresses several issues in the container startup scripts:

- Removes a redundant call to `setup-wine.sh` in `entrypoint.sh`. The script was being called twice, and the second call had better error handling.
- Removes noisy and ineffective permission checks for `/tmp/.X11-unix` from `entrypoint.sh`. The `setup-wine.sh` script already handles the case where this directory is not writable more gracefully.
- Downgrades the log level from ERROR to WARN in `setup-waydroid.sh` when required Android kernel modules are missing. This better reflects that it's an environmental constraint rather than a script failure.