### PR TITLE
Capture default audio monitor and expose browser config

### DIFF
--- a/public/audio-env.js
+++ b/public/audio-env.js
@@ -1,0 +1,3 @@
+window.AUDIO_HOST = window.AUDIO_HOST || window.location.hostname;
+window.AUDIO_PORT = window.AUDIO_PORT || 8080;
+window.AUDIO_WS_SCHEME = window.AUDIO_WS_SCHEME || (window.location.protocol === 'https:' ? 'wss' : 'ws');

--- a/ubuntu-kde-docker/setup-audio-bridge.sh
+++ b/ubuntu-kde-docker/setup-audio-bridge.sh
@@ -72,11 +72,11 @@ wss.on('connection', (ws) => {
     const startRecording = () => {
         // Try different PulseAudio connection methods
         const parecordOptions = [
-            // Try default (local socket)
-            ['--format=s16le', '--rate=44100', '--channels=2', '--raw'],
-            // Try TCP server fallback
-            ['--server=tcp:localhost:4713', '--format=s16le', '--rate=44100', '--channels=2', '--raw'],
-            // Try specific device fallback
+            // Record from the default sink's monitor (local socket)
+            ['--device=default.monitor', '--format=s16le', '--rate=44100', '--channels=2', '--raw'],
+            // Try TCP server fallback using the default monitor
+            ['--server=tcp:localhost:4713', '--device=default.monitor', '--format=s16le', '--rate=44100', '--channels=2', '--raw'],
+            // Final fallback: explicit virtual speaker monitor
             ['--device=virtual_speaker.monitor', '--format=s16le', '--rate=44100', '--channels=2', '--raw']
         ];
         


### PR DESCRIPTION
## Summary
- Stream audio from the system's active output by recording the default PulseAudio monitor with a fallback to the virtual speaker
- Expose audio bridge host, port and WebSocket scheme to the browser via a new `audio-env.js` file

## Testing
- `npm test`
- `node ubuntu-kde-docker/test/audio-bridge.test.cjs` *(fails: fetch failed)*

------
https://chatgpt.com/codex/tasks/task_b_689115cf6120832f8a85a89d62f2941b