### PR TITLE
chore: provide novnc package metadata

### DIFF
--- a/ubuntu-kde-docker/entrypoint.sh
+++ b/ubuntu-kde-docker/entrypoint.sh
@@ -86,6 +86,16 @@ else
     echo "❌ Failed to create audio environment configuration"
 fi
 
+# Provide package metadata expected by noVNC's UI
+if [ ! -f /usr/share/novnc/package.json ]; then
+    cat > /usr/share/novnc/package.json <<'EOF'
+{
+  "name": "novnc",
+  "version": "1.0.0"
+}
+EOF
+fi
+
 # Initialize system directories
 mkdir -p /var/run/dbus /tmp/.ICE-unix /tmp/.X11-unix
 chmod 1777 /tmp/.ICE-unix


### PR DESCRIPTION
## Summary
- ensure `/usr/share/novnc/package.json` exists to prevent missing file errors in noVNC UI

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_689126e6c594832fbeb4308a7dd8299a