### PR TITLE
fix: move base image declaration to top

### DIFF
--- a/ubuntu-kde-docker/Dockerfile
+++ b/ubuntu-kde-docker/Dockerfile
@@ -1,7 +1,8 @@
+FROM ubuntu:24.04
+
 # Copy and set permissions for diagnostic-and-fix.sh
 COPY diagnostic-and-fix.sh /usr/local/bin/diagnostic-and-fix.sh
 RUN chmod +x /usr/local/bin/diagnostic-and-fix.sh
-FROM ubuntu:24.04
 
 ENV DEBIAN_FRONTEND=noninteractive
 


### PR DESCRIPTION
## Summary
- ensure ubuntu base image is declared before any commands in Dockerfile
- copy diagnostic script after base image is defined

## Testing
- `docker --version`
- `dockerd` *(fails: failed to mount overlay: operation not permitted)*

------
https://chatgpt.com/codex/tasks/task_b_68921590591c832f9af9107219ffe7d7