### PR TITLE
fix: ensure diagnostic script is executable

### DIFF
--- a/ubuntu-kde-docker/Dockerfile
+++ b/ubuntu-kde-docker/Dockerfile
@@ -1,7 +1,8 @@
+FROM ubuntu:24.04
+
 # Copy and set permissions for diagnostic-and-fix.sh
 COPY diagnostic-and-fix.sh /usr/local/bin/diagnostic-and-fix.sh
 RUN chmod +x /usr/local/bin/diagnostic-and-fix.sh
-FROM ubuntu:24.04
 
 ENV DEBIAN_FRONTEND=noninteractive
 
@@ -242,6 +243,9 @@ COPY xstartup /tmp/xstartup
 COPY entrypoint.sh /entrypoint.sh
 RUN chmod +x /entrypoint.sh /tmp/xstartup
 
+
+# Ensure diagnostic script remains present and executable
+RUN test -x /usr/local/bin/diagnostic-and-fix.sh
 
 # Run diagnostic-and-fix.sh before entrypoint.sh
 ENTRYPOINT ["/bin/bash", "-c", "/usr/local/bin/diagnostic-and-fix.sh && exec /entrypoint.sh"]


### PR DESCRIPTION
## Summary
- ensure ubuntu base image is declared before any commands in Dockerfile
- copy diagnostic script after base image and verify it remains executable in the final image

## Testing
- `docker --version`
- `dockerd` *(fails: failed to mount overlay and could not register bridge driver)*
- `docker build -f ubuntu-kde-docker/Dockerfile ubuntu-kde-docker` *(fails: cannot connect to the Docker daemon)*

------
https://chatgpt.com/codex/tasks/task_b_68921590591c832f9af9107219ffe7d7