### PR TITLE
refactor: enhance audio diagnostic script

### DIFF
--- a/ubuntu-kde-docker/diagnostic-and-fix.sh
+++ b/ubuntu-kde-docker/diagnostic-and-fix.sh
@@ -1,45 +1,76 @@
 #!/bin/bash
 # diagnostic-and-fix.sh: Automatic audio diagnostic and fix script for WebTop container
-set -e
+set -euo pipefail
 
-LOG_FILE="/tmp/audio_diagnostic.log"
-echo "[INFO] Starting audio diagnostic..." | tee "$LOG_FILE"
+LOG_FILE="${LOG_FILE:-/tmp/audio_diagnostic.log}"
+: >"$LOG_FILE"
+
+log() {
+  local level="$1"; shift
+  local timestamp
+  timestamp="$(date '+%Y-%m-%d %H:%M:%S')"
+  echo "[$timestamp] [$level] $*" | tee -a "$LOG_FILE"
+}
+
+# Ensure required commands exist
+for cmd in pulseaudio pactl pgrep pkill; do
+  if ! command -v "$cmd" >/dev/null 2>&1; then
+    log ERROR "Required command '$cmd' not found"
+    exit 1
+  fi
+done
+
+log INFO "Starting audio diagnostic..."
 
 # 1. Check PulseAudio status
-echo "[INFO] Checking PulseAudio status..." | tee -a "$LOG_FILE"
+log INFO "Checking PulseAudio status..."
 if ! pulseaudio --check 2>/dev/null; then
-  echo "[WARN] PulseAudio is not running. Starting PulseAudio..." | tee -a "$LOG_FILE"
-  pulseaudio --start
+  log WARN "PulseAudio is not running. Attempting to start..."
+  pulseaudio --start >>"$LOG_FILE" 2>&1 || log ERROR "Failed to start PulseAudio"
 else
-  echo "[INFO] PulseAudio is running." | tee -a "$LOG_FILE"
+  log INFO "PulseAudio is running."
 fi
 
 # 2. List sinks and sources
-echo "[INFO] Listing sinks and sources..." | tee -a "$LOG_FILE"
+log INFO "Listing sinks and sources..."
 pactl list short sinks | tee -a "$LOG_FILE"
 pactl list short sources | tee -a "$LOG_FILE"
 
+DEFAULT_SINK="virtual_speaker"
+
 # 3. Ensure virtual_speaker exists
-if ! pactl list short sinks | grep -q 'virtual_speaker'; then
-  echo "[WARN] virtual_speaker not found. Creating..." | tee -a "$LOG_FILE"
-  pactl load-module module-null-sink sink_name=virtual_speaker sink_properties=device.description=Virtual_Marketing_Speaker
+if ! pactl list short sinks | grep -q "$DEFAULT_SINK"; then
+  log WARN "$DEFAULT_SINK not found. Creating..."
+  pactl load-module module-null-sink \
+    sink_name="$DEFAULT_SINK" \
+    sink_properties=device.description=Virtual_Marketing_Speaker \
+    >>"$LOG_FILE" 2>&1 || log ERROR "Failed to create $DEFAULT_SINK"
 else
-  echo "[INFO] virtual_speaker exists." | tee -a "$LOG_FILE"
+  log INFO "$DEFAULT_SINK exists."
 fi
 
-# 4. Set default sink to virtual_speaker
-pactl set-default-sink virtual_speaker
+# 4. Set default sink to virtual_speaker and move existing streams
+if pactl set-default-sink "$DEFAULT_SINK" >>"$LOG_FILE" 2>&1; then
+  log INFO "Default sink set to $DEFAULT_SINK"
+  pactl list short sink-inputs | awk '{print $1}' | while read -r input; do
+    if [ -n "$input" ]; then
+      pactl move-sink-input "$input" "$DEFAULT_SINK" >>"$LOG_FILE" 2>&1 || true
+    fi
+  done
+else
+  log ERROR "Failed to set default sink to $DEFAULT_SINK"
+fi
 
 # 5. Unmute and set volume to 100%
-pactl set-sink-mute virtual_speaker 0
-pactl set-sink-volume virtual_speaker 100%
+pactl set-sink-mute "$DEFAULT_SINK" 0 >>"$LOG_FILE" 2>&1 || true
+pactl set-sink-volume "$DEFAULT_SINK" 100% >>"$LOG_FILE" 2>&1 || true
 
 # 6. Restart audio bridge if present
-if pgrep -f 'audio-bridge'; then
-  echo "[INFO] Restarting audio-bridge..." | tee -a "$LOG_FILE"
-  pkill -f 'audio-bridge'
+if pgrep -f 'audio-bridge' >/dev/null; then
+  log INFO "Restarting audio-bridge..."
+  pkill -f 'audio-bridge' || true
   sleep 1
-  nohup audio-bridge &
+  nohup audio-bridge >>"$LOG_FILE" 2>&1 &
 fi
 
-echo "[INFO] Audio diagnostic and fix completed." | tee -a "$LOG_FILE"
+log INFO "Audio diagnostic and fix completed."

--- a/ubuntu-kde-docker/test/diagnostic-and-fix.test.cjs
+++ b/ubuntu-kde-docker/test/diagnostic-and-fix.test.cjs
@@ -1,0 +1,203 @@
+const test = require('node:test');
+const assert = require('node:assert');
+const fs = require('fs');
+const path = require('path');
+const os = require('os');
+const { spawnSync } = require('child_process');
+
+// helper to find real path of a command
+function findCmd(cmd) {
+  for (const dir of ['/usr/bin', '/bin']) {
+    const full = path.join(dir, cmd);
+    if (fs.existsSync(full)) return full;
+  }
+  throw new Error(`command not found: ${cmd}`);
+}
+
+function writeStub(dir, name, content) {
+  const file = path.join(dir, name);
+  fs.writeFileSync(file, content);
+  fs.chmodSync(file, 0o755);
+}
+
+const script = path.join(__dirname, '..', 'diagnostic-and-fix.sh');
+
+// Test: failure when a required command is missing
+// -----------------------------------------------
+test('fails if required command missing', () => {
+  const stubDir = fs.mkdtempSync(path.join(os.tmpdir(), 'diagfix-missing-'));
+  // provide minimal utilities for log function
+  fs.symlinkSync(findCmd('date'), path.join(stubDir, 'date'));
+  fs.symlinkSync(findCmd('tee'), path.join(stubDir, 'tee'));
+  const logFile = path.join(stubDir, 'log');
+  const result = spawnSync('/bin/bash', [script], {
+    env: { LOG_FILE: logFile, PATH: stubDir },
+    encoding: 'utf8',
+  });
+  assert.notStrictEqual(result.status, 0);
+  const log = fs.readFileSync(logFile, 'utf8');
+  assert.match(log, /Required command 'pulseaudio' not found/);
+});
+
+// Shared stubs for remaining tests
+function setupBaseEnv(opts = {}) {
+  const stubDir = fs.mkdtempSync(path.join(os.tmpdir(), 'diagfix-stub-'));
+  const stubLog = path.join(stubDir, 'stub.log');
+
+  // pulseaudio stub
+  writeStub(stubDir, 'pulseaudio', `#!/bin/bash\n` +
+    `echo "pulseaudio $@" >>"$STUB_OUT"\n` +
+    `if [ "$1" = "--check" ]; then\n` +
+    `  exit ${opts.paCheck ?? 0}\n` +
+    `elif [ "$1" = "--start" ]; then\n` +
+    `  echo "pulseaudio started" >>"$STUB_OUT"\n` +
+    `  exit 0\n` +
+    `fi`);
+
+  // pactl stub
+  writeStub(stubDir, 'pactl', `#!/bin/bash\n` +
+    `echo "pactl $@" >>"$STUB_OUT"\n` +
+    `if [ "$1" = "list" ] && [ "$2" = "short" ] && [ "$3" = "sinks" ]; then\n` +
+    `  printf "%s" "${opts.sinks ?? ''}"\n` +
+    `elif [ "$1" = "list" ] && [ "$2" = "short" ] && [ "$3" = "sources" ]; then\n` +
+    `  printf "%s" "${opts.sources ?? ''}"\n` +
+    `elif [ "$1" = "list" ] && [ "$2" = "short" ] && [ "$3" = "sink-inputs" ]; then\n` +
+    `  printf "%s" "${opts.sinkInputs ?? ''}"\n` +
+    `fi`);
+
+  // pgrep stub
+  writeStub(stubDir, 'pgrep', `#!/bin/bash\n` +
+    `echo "pgrep $@" >>"$STUB_OUT"\n` +
+    `if [ ${opts.audioBridgePresent ? 1 : 0} -eq 1 ]; then exit 0; else exit 1; fi`);
+
+  // pkill stub
+  writeStub(stubDir, 'pkill', `#!/bin/bash\n` +
+    `echo "pkill $@" >>"$STUB_OUT"`);
+
+  // audio-bridge stub
+  writeStub(stubDir, 'audio-bridge', `#!/bin/bash\n` +
+    `echo "audio-bridge invoked" >>"$STUB_OUT"`);
+
+  // link other required utilities
+  for (const cmd of ['date', 'tee', 'grep', 'awk', 'sleep', 'nohup']) {
+    const real = findCmd(cmd);
+    fs.symlinkSync(real, path.join(stubDir, cmd));
+  }
+
+  return { stubDir, stubLog };
+}
+
+// Test: starts pulseaudio when not running
+// ----------------------------------------
+test('starts pulseaudio when not running', () => {
+  const { stubDir, stubLog } = setupBaseEnv({ paCheck: 1 });
+  const logFile = path.join(stubDir, 'log');
+  const result = spawnSync('/bin/bash', [script], {
+    env: {
+      LOG_FILE: logFile,
+      PATH: `${stubDir}:/usr/bin:/bin`,
+      STUB_OUT: stubLog,
+    },
+    encoding: 'utf8',
+  });
+  assert.strictEqual(result.status, 0);
+  const stub = fs.readFileSync(stubLog, 'utf8');
+  assert.match(stub, /pulseaudio --start/);
+});
+
+// Test: skips starting pulseaudio if already running
+// --------------------------------------------------
+test('does not start pulseaudio when already running', () => {
+  const { stubDir, stubLog } = setupBaseEnv({ paCheck: 0 });
+  const logFile = path.join(stubDir, 'log');
+  const result = spawnSync('/bin/bash', [script], {
+    env: {
+      LOG_FILE: logFile,
+      PATH: `${stubDir}:/usr/bin:/bin`,
+      STUB_OUT: stubLog,
+    },
+    encoding: 'utf8',
+  });
+  assert.strictEqual(result.status, 0);
+  const stub = fs.readFileSync(stubLog, 'utf8');
+  assert.ok(!stub.includes('pulseaudio --start'));
+});
+
+// Test: create virtual_speaker only when absent
+// ---------------------------------------------
+test('creates virtual_speaker sink when missing', () => {
+  const { stubDir, stubLog } = setupBaseEnv({ paCheck: 0, sinks: '1\tsome_sink\n' });
+  const logFile = path.join(stubDir, 'log');
+  spawnSync('/bin/bash', [script], {
+    env: {
+      LOG_FILE: logFile,
+      PATH: `${stubDir}:/usr/bin:/bin`,
+      STUB_OUT: stubLog,
+    },
+    encoding: 'utf8',
+  });
+  const stub = fs.readFileSync(stubLog, 'utf8');
+  assert.match(stub, /pactl load-module/);
+});
+
+// ensure load-module not called when sink exists
+test('does not create sink when already present', () => {
+  const { stubDir, stubLog } = setupBaseEnv({ paCheck: 0, sinks: '1\tvirtual_speaker\n' });
+  const logFile = path.join(stubDir, 'log');
+  spawnSync('/bin/bash', [script], {
+    env: {
+      LOG_FILE: logFile,
+      PATH: `${stubDir}:/usr/bin:/bin`,
+      STUB_OUT: stubLog,
+    },
+    encoding: 'utf8',
+  });
+  const stub = fs.readFileSync(stubLog, 'utf8');
+  assert.ok(!/pactl load-module/.test(stub));
+});
+
+// Test: restart audio-bridge when present
+// ---------------------------------------
+test('restarts audio-bridge when running', () => {
+  const { stubDir, stubLog } = setupBaseEnv({ paCheck: 0, audioBridgePresent: true, sinks: '1\tvirtual_speaker\n' });
+  const logFile = path.join(stubDir, 'log');
+  const result = spawnSync('/bin/bash', [script], {
+    env: {
+      LOG_FILE: logFile,
+      PATH: `${stubDir}:/usr/bin:/bin`,
+      STUB_OUT: stubLog,
+    },
+    encoding: 'utf8',
+  });
+  assert.strictEqual(result.status, 0);
+  const stub = fs.readFileSync(stubLog, 'utf8');
+  assert.match(stub, /pgrep -f audio-bridge/);
+  assert.match(stub, /pkill -f audio-bridge/);
+  assert.match(stub, /audio-bridge invoked/);
+  const log = fs.readFileSync(logFile, 'utf8');
+  assert.match(log, /Restarting audio-bridge/);
+});
+
+// ensure audio-bridge not restarted when absent
+test('does not restart audio-bridge when not running', () => {
+  const { stubDir, stubLog } = setupBaseEnv({
+    paCheck: 0,
+    audioBridgePresent: false,
+    sinks: '1\tvirtual_speaker\n',
+  });
+  const logFile = path.join(stubDir, 'log');
+  const result = spawnSync('/bin/bash', [script], {
+    env: {
+      LOG_FILE: logFile,
+      PATH: `${stubDir}:/usr/bin:/bin`,
+      STUB_OUT: stubLog,
+    },
+    encoding: 'utf8',
+  });
+  assert.strictEqual(result.status, 0);
+  const stub = fs.readFileSync(stubLog, 'utf8');
+  assert.ok(!/pkill -f audio-bridge/.test(stub));
+  assert.ok(!/audio-bridge invoked/.test(stub));
+  const log = fs.readFileSync(logFile, 'utf8');
+  assert.ok(!/Restarting audio-bridge/.test(log));
+});


### PR DESCRIPTION
## Summary
- add strict error handling and timestamped log helper to audio diagnostic script
- verify required audio utilities and create missing virtual sink before setting as default
- move active streams to virtual sink, restart audio bridge, and expand integration tests to cover command availability, PulseAudio start logic, sink creation, bridge restart, and bridge absence

## Testing
- `shellcheck ubuntu-kde-docker/diagnostic-and-fix.sh`
- `node --test ubuntu-kde-docker/test/diagnostic-and-fix.test.cjs`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_b_68921614b0f4832fb32628613415cdab