### PR TITLE
Ensure X11 socket permissions for Wine Xvfb setup

### DIFF
--- a/ubuntu-kde-docker/entrypoint.sh
+++ b/ubuntu-kde-docker/entrypoint.sh
@@ -98,7 +98,8 @@ fi
 
 # Initialize system directories
 mkdir -p /var/run/dbus /tmp/.ICE-unix /tmp/.X11-unix
-chmod 1777 /tmp/.ICE-unix
+# Ensure world-writable permissions for X11 and ICE sockets
+chmod 1777 /tmp/.ICE-unix /tmp/.X11-unix
 
 # Replace default username in polkit rule if different
 if [ -f /etc/polkit-1/rules.d/99-devuser-all.rules ]; then


### PR DESCRIPTION
## Summary
- ensure /tmp/.X11-unix is world-writable to allow Xvfb startup

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_68922ad68400832f8c9fae023b41c76e