### PR TITLE
Ensure virtual speaker remains default sink

### DIFF
--- a/ubuntu-kde-docker/README_AUDIO.md
+++ b/ubuntu-kde-docker/README_AUDIO.md
@@ -81,6 +81,7 @@ Desktop Apps → PulseAudio → Virtual Sink → Audio Bridge → WebSocket → 
 1. Check that audio bridge is running: `docker logs webtop-kde | grep "Audio bridge"`
 2. Verify WebSocket connection in browser console
 3. Try disconnecting and reconnecting audio
+4. Confirm PulseAudio's default sink is set to `virtual_speaker`. The system now automatically resets it, or run `/usr/local/bin/fix-audio-routing.sh` manually
 
 ### Audio Bridge Not Starting
 1. Check container logs: `docker logs webtop-kde`


### PR DESCRIPTION
## Summary
- enforce that audio-monitor keeps PulseAudio's default sink pointed at `virtual_speaker`
- document troubleshooting step to reset default sink when browser audio is silent

## Testing
- `node test/audio-bridge.test.cjs`


------
https://chatgpt.com/codex/tasks/task_b_68922ea57634832f89e93a2981565665