### PR TITLE
Handle read-only X11 socket directory

### DIFF
--- a/ubuntu-kde-docker/entrypoint.sh
+++ b/ubuntu-kde-docker/entrypoint.sh
@@ -99,7 +99,9 @@ fi
 # Initialize system directories
 mkdir -p /var/run/dbus /tmp/.ICE-unix /tmp/.X11-unix
 # Ensure world-writable permissions for X11 and ICE sockets
-chmod 1777 /tmp/.ICE-unix /tmp/.X11-unix
+# /tmp/.X11-unix may be mounted read-only by the host
+chmod 1777 /tmp/.ICE-unix 2>/dev/null || log_warn "/tmp/.ICE-unix permissions could not be set"
+chmod 1777 /tmp/.X11-unix 2>/dev/null || log_warn "/tmp/.X11-unix is not writable; skipping chmod"
 
 # Replace default username in polkit rule if different
 if [ -f /etc/polkit-1/rules.d/99-devuser-all.rules ]; then


### PR DESCRIPTION
## Summary
- avoid failing when `/tmp/.X11-unix` is read-only by logging a warning

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_b_6892375dcc24832fb4393ce030efd129