### PR TITLE
feat(audio): support proxied websocket path

### DIFF
--- a/ubuntu-kde-docker/setup-audio-bridge.sh
+++ b/ubuntu-kde-docker/setup-audio-bridge.sh
@@ -2,6 +2,9 @@
 
 # Audio Bridge Setup Script
 # Sets up web-based audio streaming from PulseAudio to browser
+# WebSocket server is mounted at /audio-bridge; clients should connect via
+# ws(s)://<host>:8080/audio-bridge or a reverse-proxied equivalent rather than
+# the server root
 
 set -e
 
@@ -78,7 +81,13 @@ server.listen(PORT, () => {
 });
 
 // WebSocket server for audio streaming
-const wss = new WebSocket.Server({ server });
+// Allow the websocket server to be mounted behind a reverse proxy
+// using a specific path (e.g. /audio-bridge).  This matches the
+// connection attempts performed by the frontend's UniversalAudioManager
+// which will try both the raw port and the proxied path.  Without
+// specifying the path here the connection would only succeed when the
+// bridge was exposed at the server root.
+const wss = new WebSocket.Server({ server, path: '/audio-bridge' });
 
 wss.on('connection', (ws) => {
     console.log('Client connected for audio streaming');

--- a/ubuntu-kde-docker/test/audio-bridge.test.cjs
+++ b/ubuntu-kde-docker/test/audio-bridge.test.cjs
@@ -1,12 +1,28 @@
 const test = require('node:test');
 const assert = require('node:assert');
 const { spawn } = require('child_process');
-
+const fs = require('node:fs');
+const os = require('node:os');
+const path = require('node:path');
+const { WebSocket, WebSocketServer } = require('/opt/audio-bridge/node_modules/ws');
 
 const wait = (ms) => new Promise((res) => setTimeout(res, ms));
 
-test('audio bridge serves static files', async (t) => {
-  const server = spawn('node', ['/opt/audio-bridge/server.js']);
+test('audio bridge server', async (t) => {
+  // Create a parecord stub that emits dummy audio data
+  const stubDir = fs.mkdtempSync(path.join(os.tmpdir(), 'parecord-'));
+  const stubPath = path.join(stubDir, 'parecord');
+  fs.writeFileSync(
+    stubPath,
+    `#!/usr/bin/env node\n` +
+      `setInterval(() => process.stdout.write(Buffer.alloc(4)), 20);\n` +
+      `process.stdin.resume();\n`
+  );
+  fs.chmodSync(stubPath, 0o755);
+
+  const server = spawn('node', ['/opt/audio-bridge/server.js'], {
+    env: { ...process.env, PATH: `${stubDir}:${process.env.PATH}` },
+  });
   t.after(() => server.kill());
 
   // give the server a moment to start
@@ -25,4 +41,61 @@ test('audio bridge serves static files', async (t) => {
     const body = await res.text();
     assert.ok(body.includes('<title>Desktop Audio</title>'));
   });
+
+  await t.test('WebSocket direct connection', async () => {
+    const ws = new WebSocket('ws://localhost:8080/audio-bridge');
+    const message = await new Promise((resolve, reject) => {
+      const timeout = setTimeout(() => reject(new Error('timeout')), 2000);
+      ws.once('message', (data) => {
+        clearTimeout(timeout);
+        resolve(data);
+      });
+      ws.once('error', (err) => {
+        clearTimeout(timeout);
+        reject(err);
+      });
+    });
+    assert.ok(message.length > 0);
+    ws.close();
+  });
+
+  await t.test('WebSocket fails without /audio-bridge path', async () => {
+    await assert.rejects(
+      () =>
+        new Promise((resolve, reject) => {
+          const ws = new WebSocket('ws://localhost:8080');
+          ws.on('open', resolve);
+          ws.on('error', reject);
+        }),
+      /unexpected server response/i
+    );
+  });
+
+  await t.test('WebSocket proxied connection', async () => {
+    const proxy = new WebSocketServer({ port: 8099, path: '/audio-bridge' });
+    proxy.on('connection', (client) => {
+      const target = new WebSocket('ws://localhost:8080/audio-bridge');
+      client.on('close', () => target.close());
+      client.on('message', (msg) => target.send(msg));
+      target.on('message', (msg) => client.send(msg));
+      target.on('close', () => client.close());
+    });
+    t.after(() => proxy.close());
+
+    const ws = new WebSocket('ws://localhost:8099/audio-bridge');
+    const message = await new Promise((resolve, reject) => {
+      const timeout = setTimeout(() => reject(new Error('timeout')), 2000);
+      ws.once('message', (data) => {
+        clearTimeout(timeout);
+        resolve(data);
+      });
+      ws.once('error', (err) => {
+        clearTimeout(timeout);
+        reject(err);
+      });
+    });
+    assert.ok(message.length > 0);
+    ws.close();
+  });
 });
+

--- a/ubuntu-kde-docker/universal-audio.js
+++ b/ubuntu-kde-docker/universal-audio.js
@@ -402,8 +402,14 @@
 
         async attemptConnection() {
             const wsProtocol = window.AUDIO_WS_SCHEME || (window.location.protocol === 'https:' ? 'wss' : 'ws');
+            // Try multiple websocket endpoints in order of preference. The
+            // first entry connects directly to the audio bridge port while the
+            // following entries allow the service to be accessed when it is
+            // proxied behind the primary web interface (with or without a
+            // path prefix).
             const wsUrls = [
                 `${wsProtocol}://${audioHost}:${audioPort}`,
+                `${wsProtocol}://${window.location.host}`,
                 `${wsProtocol}://${window.location.host}/audio-bridge`
             ];
 


### PR DESCRIPTION
## Summary
- support `/audio-bridge` websocket path in audio bridge server
- try additional host-based websocket endpoints in universal audio manager
- add tests covering direct/proxied WebSocket connections and wrong-path failures
- document `/audio-bridge` websocket path in setup script

## Testing
- `bash ubuntu-kde-docker/setup-audio-bridge.sh` *(terminated early after nodejs installation)*
- `node ubuntu-kde-docker/test/audio-bridge.test.cjs` *(fails: Cannot find module '/opt/audio-bridge/node_modules/ws')*


------
https://chatgpt.com/codex/tasks/task_b_6892735c3ff0832fbe6cc111881f1a05