### PR TITLE
Enable host audio in WebTop container

### DIFF
--- a/ubuntu-kde-docker/Dockerfile
+++ b/ubuntu-kde-docker/Dockerfile
@@ -9,6 +9,12 @@ ENV DEBIAN_FRONTEND=noninteractive
 # Enable 32-bit architecture for Wine support
 RUN dpkg --add-architecture i386
 
+# Install core audio packages and allow root to access audio devices
+RUN apt-get update && \
+    apt-get install -y pulseaudio pavucontrol alsa-utils && \
+    rm -rf /var/lib/apt/lists/*
+RUN usermod -aG audio root
+
 # Install all required packages and lightweight fallback WM
 RUN apt-get update && apt-get install -y \
     sudo wget curl gnupg2 apt-transport-https software-properties-common \

--- a/ubuntu-kde-docker/README.md
+++ b/ubuntu-kde-docker/README.md
@@ -40,6 +40,33 @@ A comprehensive Docker environment featuring Ubuntu with KDE Plasma desktop, spe
 - 4GB+ RAM recommended
 - Modern web browser
 
+### Host Audio Setup
+The Docker image installs `pulseaudio`, `pavucontrol`, and `alsa-utils` and adds the `root` user to the `audio` group. To output
+real audio instead of only virtual sinks, the host must run PulseAudio and share its socket and sound devices with the
+container.
+
+```bash
+apt update && apt install pulseaudio alsa-utils -y
+pulseaudio --start
+pactl list short sinks   # verify a real sink is available
+```
+
+The provided Docker Compose files already configure the required mounts and environment variables:
+
+```yaml
+environment:
+  - PULSE_SERVER=unix:/run/user/0/pulse/native
+volumes:
+  - /run/user/0/pulse:/run/user/0/pulse
+  - /root/.config/pulse/cookie:/root/.config/pulse/cookie
+  - /tmp/.X11-unix:/tmp/.X11-unix
+devices:
+  - /dev/snd
+```
+
+Ensure `/tmp/.X11-unix` is writable on the host (`chmod 1777 /tmp/.X11-unix`) and that `pactl list short sinks` reports a
+hardware sink before starting the container.
+
 ### 1. Clone & Configure
 ```bash
 git clone <repository>

--- a/ubuntu-kde-docker/docker-compose.dev.yml
+++ b/ubuntu-kde-docker/docker-compose.dev.yml
@@ -11,16 +11,20 @@ services:
       - "32768:80"      # noVNC
       - "2222:22"       # SSH
       - "7681:7681"     # ttyd terminal
-      
+
       - "4713:4713"     # PulseAudio
     env_file:
       - .env
+    environment:
+      - PULSE_SERVER=unix:/run/user/0/pulse/native
     volumes:
       - /data/ubuntu-kde-docker_webtop/config:/config
       - /data/ubuntu-kde-docker_webtop/var/log/supervisor:/var/log/supervisor
-      - /data/ubuntu-kde-docker_webtop/tmp/.X11-unix:/tmp/.X11-unix:ro
+      - /run/user/0/pulse:/run/user/0/pulse
+      - /root/.config/pulse/cookie:/root/.config/pulse/cookie
+      - /tmp/.X11-unix:/tmp/.X11-unix
     devices:
-      - /dev/snd:/dev/snd
+      - /dev/snd
     tmpfs:
       - /tmp
       - /run

--- a/ubuntu-kde-docker/docker-compose.prod.yml
+++ b/ubuntu-kde-docker/docker-compose.prod.yml
@@ -11,13 +11,17 @@ services:
       - "2222:22"     # SSH
     env_file:
       - .env.production
+    environment:
+      - PULSE_SERVER=unix:/run/user/0/pulse/native
     volumes:
       - /data/ubuntu-kde-docker_webtop/config:/config
       - /data/ubuntu-kde-docker_webtop/var/log/supervisor:/var/log/supervisor
-      - /data/ubuntu-kde-docker_webtop/tmp/.X11-unix:/tmp/.X11-unix:ro
+      - /run/user/0/pulse:/run/user/0/pulse
+      - /root/.config/pulse/cookie:/root/.config/pulse/cookie
+      - /tmp/.X11-unix:/tmp/.X11-unix
       - /etc/ssl/certs:/etc/ssl/certs:ro
     devices:
-      - /dev/snd:/dev/snd
+      - /dev/snd
     tmpfs:
       - /tmp
       - /run

--- a/ubuntu-kde-docker/docker-compose.yml
+++ b/ubuntu-kde-docker/docker-compose.yml
@@ -17,12 +17,16 @@ services:
       - "4713:4713"     # PulseAudio
     env_file:
       - .env
+    environment:
+      - PULSE_SERVER=unix:/run/user/0/pulse/native
     volumes:
       - /data/ubuntu-kde-docker_webtop/config:/config
       - /data/ubuntu-kde-docker_webtop/var/log/supervisor:/var/log/supervisor
-      - /data/ubuntu-kde-docker_webtop/tmp/.X11-unix:/tmp/.X11-unix:ro
+      - /run/user/0/pulse:/run/user/0/pulse
+      - /root/.config/pulse/cookie:/root/.config/pulse/cookie
+      - /tmp/.X11-unix:/tmp/.X11-unix
     devices:
-      - /dev/snd:/dev/snd
+      - /dev/snd
     tmpfs:
       - /tmp
       - /run


### PR DESCRIPTION
## Summary
- add pulseaudio/alsa tools in Dockerfile and ensure root joins audio group
- mount host PulseAudio socket, cookie, and X11 directory and expose `/dev/snd` in docker-compose configurations

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_689293e52124832f8d9a864d650c7c29