### PR TITLE
Improve PulseAudio fallback

### DIFF
--- a/ubuntu-kde-docker/Dockerfile
+++ b/ubuntu-kde-docker/Dockerfile
@@ -176,6 +176,7 @@ COPY health-check.sh /usr/local/bin/health-check.sh
 COPY fix-permissions.sh /usr/local/bin/fix-permissions.sh
 COPY test-polkit.sh /usr/local/bin/test-polkit.sh
 COPY create-virtual-audio-devices.sh /usr/local/bin/create-virtual-audio-devices.sh
+COPY fix-audio-routing.sh /usr/local/bin/fix-audio-routing.sh
 COPY setup-universal-audio.sh /usr/local/bin/setup-universal-audio.sh
 RUN chmod +x /usr/local/bin/setup-*.sh \
     /usr/local/bin/service-health.sh \
@@ -186,7 +187,8 @@ RUN chmod +x /usr/local/bin/setup-*.sh \
     /usr/local/bin/fix-permissions.sh \
     /usr/local/bin/test-polkit.sh \
     /usr/local/bin/fix-audio-startup.sh \
-    /usr/local/bin/create-virtual-audio-devices.sh
+    /usr/local/bin/create-virtual-audio-devices.sh \
+    /usr/local/bin/fix-audio-routing.sh
 
 # Initialize audio system during build
 RUN /usr/local/bin/setup-audio.sh && \

--- a/ubuntu-kde-docker/audio-validation.sh
+++ b/ubuntu-kde-docker/audio-validation.sh
@@ -100,8 +100,10 @@ echo "🎵 Testing audio system from desktop..."
 
 # Test PulseAudio connectivity
 echo "Testing PulseAudio connection..."
-if pactl info; then
-    echo "✅ PulseAudio connection successful"
+if pactl info >/dev/null 2>&1; then
+    echo "✅ PulseAudio connection successful (local)"
+elif pactl -s tcp:localhost:4713 info >/dev/null 2>&1; then
+    echo "✅ PulseAudio connection successful (TCP)"
 else
     echo "❌ PulseAudio connection failed"
     exit 1
@@ -110,11 +112,11 @@ fi
 # List available devices
 echo ""
 echo "Available audio sinks:"
-pactl list short sinks
+pactl list short sinks 2>/dev/null || pactl -s tcp:localhost:4713 list short sinks
 
 echo ""
 echo "Available audio sources:"
-pactl list short sources
+pactl list short sources 2>/dev/null || pactl -s tcp:localhost:4713 list short sources
 
 # Test audio generation
 echo ""

--- a/ubuntu-kde-docker/setup-audio.sh
+++ b/ubuntu-kde-docker/setup-audio.sh
@@ -238,24 +238,24 @@ test_audio_devices() {
     echo "🔍 Testing audio devices..."
     
     echo "Available audio sinks:"
-    if pactl list short sinks 2>/dev/null; then
+    if pactl list short sinks 2>/dev/null || pactl -s tcp:localhost:4713 list short sinks 2>/dev/null; then
         green "✅ Audio sinks detected"
     else
         red "❌ No audio sinks found"
     fi
     
     echo "Available audio sources:"
-    if pactl list short sources 2>/dev/null; then
+    if pactl list short sources 2>/dev/null || pactl -s tcp:localhost:4713 list short sources 2>/dev/null; then
         green "✅ Audio sources detected"
     else
         red "❌ No audio sources found"
     fi
     
     echo "Default sink:"
-    pactl get-default-sink 2>/dev/null || red "❌ No default sink"
-    
+    pactl get-default-sink 2>/dev/null || pactl -s tcp:localhost:4713 get-default-sink 2>/dev/null || red "❌ No default sink"
+
     echo "Default source:"
-    pactl get-default-source 2>/dev/null || red "❌ No default source"
+    pactl get-default-source 2>/dev/null || pactl -s tcp:localhost:4713 get-default-source 2>/dev/null || red "❌ No default source"
 }
 
 # Test VNC audio integration


### PR DESCRIPTION
## Summary
- ensure audio test script falls back to TCP PulseAudio if local socket isn't available
- handle PulseAudio TCP fallback when creating or verifying virtual audio devices
- install missing fix-audio-routing script and enhance audio setup checks

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_b_6892a4801fdc832fbed4b4215ff93e84