### PR TITLE
fix: install node-pre-gyp for webrtc bridge

### DIFF
--- a/ubuntu-kde-docker/setup-webrtc-bridge.sh
+++ b/ubuntu-kde-docker/setup-webrtc-bridge.sh
@@ -13,6 +13,12 @@ if ! command -v node &> /dev/null; then
     apt-get install -y nodejs
 fi
 
+# The wrtc package relies on the node-pre-gyp binary during installation.
+# On some minimal images it may not be installed, causing "node-pre-gyp: not found"
+# during `npm install`.  Install it globally to ensure the dependency is present
+# before installing the bridge's packages.
+npm install -g node-pre-gyp
+
 # Create WebRTC bridge directory
 mkdir -p /opt/webrtc-bridge
 cd /opt/webrtc-bridge


### PR DESCRIPTION
## Summary
- ensure webrtc bridge setup installs node-pre-gyp to satisfy wrtc

## Testing
- `npm test`
- `bash ubuntu-kde-docker/setup-webrtc-bridge.sh`


------
https://chatgpt.com/codex/tasks/task_b_689321727de4832fb261fd5bb1f23341