### PR TITLE
The container was failing to start due to an issue in the Dockerfile …

### DIFF
--- a/ubuntu-kde-docker/Dockerfile
+++ b/ubuntu-kde-docker/Dockerfile
@@ -259,7 +259,7 @@ RUN chmod +x /entrypoint.sh /tmp/xstartup
 RUN test -x /usr/local/bin/diagnostic-and-fix.sh
 
 # Run diagnostic-and-fix.sh before entrypoint.sh
-ENTRYPOINT ["/bin/bash", "-c", "/usr/local/bin/diagnostic-and-fix.sh && exec /entrypoint.sh"]
+ENTRYPOINT ["/entrypoint.sh"]
 
 EXPOSE 22 80 5901 7681
 


### PR DESCRIPTION
…ENTRYPOINT.

The ENTRYPOINT was configured to run `diagnostic-and-fix.sh` before `entrypoint.sh`. However, the diagnostic script requires the `devuser` and `XDG_RUNTIME_DIR` to be created, which only happens inside `entrypoint.sh`.

This created a race condition where the diagnostic script would always fail, causing the container to enter a restart loop and preventing the main application from starting.

This change corrects the ENTRYPOINT to execute `entrypoint.sh` directly, which already handles the necessary setup for PipeWire and other services. This resolves the startup loop and allows the container to launch correctly.