### PR TITLE
fix: create wireplumber config subdir

### DIFF
--- a/ubuntu-kde-docker/fix-pipewire-startup.sh
+++ b/ubuntu-kde-docker/fix-pipewire-startup.sh
@@ -37,7 +37,7 @@ if [ "$IS_RUNTIME" = true ]; then
 
     # Ensure PipeWire config directory exists
     mkdir -p "/home/${DEV_USERNAME}/.config/pipewire"
-    mkdir -p "/home/${DEV_USERNAME}/.config/wireplumber"
+    mkdir -p "/home/${DEV_USERNAME}/.config/wireplumber/main.lua.d"
     chown -R "${DEV_USERNAME}:${DEV_USERNAME}" "/home/${DEV_USERNAME}/.config"
 fi
 


### PR DESCRIPTION
## Summary
- ensure WirePlumber configuration directory exists before writing virtual device rules

## Testing
- `bash -n ubuntu-kde-docker/fix-pipewire-startup.sh`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_b_6893492c30a4832fb674d7d29e7bb8a0