### PR TITLE
Fix wireplumber crash when ALSA monitor is missing

### DIFF
--- a/ubuntu-kde-docker/fix-pipewire-startup.sh
+++ b/ubuntu-kde-docker/fix-pipewire-startup.sh
@@ -65,7 +65,7 @@ context.properties = {
 EOF
 
     # Create WirePlumber configuration
-    cat <<EOF > "/home/${DEV_USERNAME}/.config/wireplumber/main.lua.d/99-virtual-devices.lua"
+    cat <<'EOF' > "/home/${DEV_USERNAME}/.config/wireplumber/main.lua.d/99-virtual-devices.lua"
 -- Virtual device configuration for container environment
 virtual_speaker_rule = {
   matches = {
@@ -103,8 +103,10 @@ virtual_microphone_rule = {
   },
 }
 
-table.insert(alsa_monitor.rules, virtual_speaker_rule)
-table.insert(alsa_monitor.rules, virtual_microphone_rule)
+if alsa_monitor and alsa_monitor.rules then
+  table.insert(alsa_monitor.rules, virtual_speaker_rule)
+  table.insert(alsa_monitor.rules, virtual_microphone_rule)
+end
 EOF
 
     chown "${DEV_USERNAME}:${DEV_USERNAME}" "/home/${DEV_USERNAME}/.config/pipewire/client.conf"


### PR DESCRIPTION
## Summary
- guard virtual device rules in WirePlumber config so they load only when `alsa_monitor` is available

## Testing
- `npm ci`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_68935f2a1d64832fa30d39925994a8d4