### PR TITLE
fix: remove redundant session manager

### DIFF
--- a/setup-pipewire.sh
+++ b/setup-pipewire.sh
@@ -65,7 +65,6 @@ context.modules = [
         args = { }
     }
     { name = libpipewire-module-link-factory }
-    { name = libpipewire-module-session-manager }
 ]
 
 context.objects = [

--- a/setup-webrtc-bridge.sh
+++ b/setup-webrtc-bridge.sh
@@ -42,6 +42,13 @@ EOF
 # Install dependencies
 npm install
 
+# The wrtc dependency may be skipped in minimal environments, which can cause
+# the `ws` module to be omitted. Ensure `ws` is present so tests can load the
+# signaling server client without failing.
+if [ ! -d node_modules/ws ]; then
+    npm install ws@^8.14.2
+fi
+
 # Create the WebRTC bridge server
 cat > server.js << 'EOF'
 const express = require('express');
@@ -59,6 +66,10 @@ const peers = new Map();
 
 app.use(express.json());
 app.use(express.static(path.join(__dirname, 'public')));
+
+app.get('/package.json', (req, res) => {
+    res.sendFile(path.join(__dirname, 'package.json'));
+});
 
 // WebRTC configuration
 const rtcConfig = {

--- a/test/audio-bridge.test.cjs
+++ b/test/audio-bridge.test.cjs
@@ -1,7 +1,17 @@
 const test = require('node:test');
 const assert = require('node:assert');
-const { spawn } = require('child_process');
-const { WebSocket } = require('/opt/webrtc-bridge/node_modules/ws');
+const { spawn, execSync } = require('child_process');
+const fs = require('node:fs');
+const path = require('node:path');
+
+// Ensure the WebRTC bridge and its dependencies are installed
+const wsModulePath = '/opt/webrtc-bridge/node_modules/ws/index.js';
+if (!fs.existsSync(wsModulePath)) {
+  const setupScript = path.resolve(__dirname, '../setup-webrtc-bridge.sh');
+  execSync(`bash ${setupScript}`, { stdio: 'inherit' });
+}
+
+const WebSocket = require(wsModulePath);
 
 const wait = (ms) => new Promise((res) => setTimeout(res, ms));
 


### PR DESCRIPTION
## Summary
- drop built-in PipeWire session manager to avoid conflicts with WirePlumber
- provision WebRTC bridge for tests and expose package metadata endpoint
- ensure WebRTC bridge installs ws dependency and test verifies installation

## Testing
- `node --test test/audio-bridge.test.cjs`


------
https://chatgpt.com/codex/tasks/task_b_6893748a0768832fa54c754cab1b5daa