### PR TITLE
Gracefully handle missing devuser in PipeWire setup

### DIFF
--- a/fix-pipewire-startup.sh
+++ b/fix-pipewire-startup.sh
@@ -32,8 +32,9 @@ main() {
     blue "🔧 Initializing PipeWire startup sequence..."
 
     if ! id "$DEV_USERNAME" >/dev/null 2>&1; then
-        red "❌ User '$DEV_USERNAME' does not exist. Aborting."
-        exit 1
+        yellow "⚠️  User '$DEV_USERNAME' does not exist. Using 'root' instead."
+        DEV_USERNAME="root"
+        DEV_UID=0
     fi
 
     # 1. Ensure runtime directories exist
@@ -45,7 +46,9 @@ main() {
     if [ -d "/dev/snd" ]; then
         chown -R root:audio /dev/snd
         chmod -R g+rw /dev/snd
-        usermod -a -G audio "${DEV_USERNAME}" 2>/dev/null || true
+        if [ "$DEV_USERNAME" != "root" ]; then
+            usermod -a -G audio "${DEV_USERNAME}" 2>/dev/null || true
+        fi
     fi
 
     # 3. Start PipeWire and WirePlumber services


### PR DESCRIPTION
## Summary
- Allow `fix-pipewire-startup.sh` to fall back to root when `devuser` doesn't exist and avoid modifying audio group for root
- Make `create-virtual-pipewire-devices.sh` detect missing user and use root with correct env vars and command invocation

## Testing
- `bash -n fix-pipewire-startup.sh create-virtual-pipewire-devices.sh`
- `shellcheck fix-pipewire-startup.sh create-virtual-pipewire-devices.sh`


------
https://chatgpt.com/codex/tasks/task_b_6893bce2f4d0832fbf0cd0ae3d2d10a3