### PR TITLE
Add supervisor config for PipeWire during build

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -182,6 +182,7 @@ COPY create-virtual-pipewire-devices.sh /usr/local/bin/create-virtual-pipewire-d
 COPY fix-pipewire-routing.sh /usr/local/bin/fix-pipewire-routing.sh
 COPY setup-universal-audio.sh /usr/local/bin/setup-universal-audio.sh
 COPY wait-for-service.sh /usr/local/bin/wait-for-service.sh
+COPY supervisord-audio-fix.conf /etc/supervisor/conf.d/pipewire.conf
 RUN chmod +x /usr/local/bin/setup-*.sh \
     /usr/local/bin/wait-for-service.sh \
     /usr/local/bin/service-health.sh \

--- a/supervisord-audio-fix.conf
+++ b/supervisord-audio-fix.conf
@@ -1,3 +1,6 @@
+[supervisord]
+nodaemon=true
+
 [program:pipewire]
 command=/usr/bin/pipewire
 autostart=true


### PR DESCRIPTION
## Summary
- copy PipeWire supervisor configuration into image
- define missing `[supervisord]` section in the config

## Testing
- `apt-get install -y pipewire wireplumber supervisor`
- `install -m 644 supervisord-audio-fix.conf /etc/supervisor/conf.d/pipewire.conf`
- `install -m 755 create-virtual-pipewire-devices.sh /usr/local/bin/create-virtual-pipewire-devices.sh`
- `DEV_USERNAME=root DEV_UID=0 bash fix-pipewire-startup.sh`
- `cat /tmp/fix.log`


------
https://chatgpt.com/codex/tasks/task_b_6893c30578e4832fb85021a797e0ab5a