### PR TITLE
Ensure supervisord expands PipeWire user variables

### DIFF
--- a/fix-pipewire-startup.sh
+++ b/fix-pipewire-startup.sh
@@ -36,6 +36,7 @@ main() {
         DEV_USERNAME="root"
         DEV_UID=0
     fi
+    export DEV_USERNAME DEV_UID
 
     # 1. Ensure runtime directories exist
     mkdir -p "/run/user/${DEV_UID}/pipewire"


### PR DESCRIPTION
## Summary
- export DEV_USERNAME and DEV_UID in PipeWire startup script before launching supervisord

## Testing
- `node test/audio-bridge.test.cjs`

------
https://chatgpt.com/codex/tasks/task_b_6893c8def39c832f830673890f314e68