### PR TITLE
Fix signal-desktop install

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -105,7 +105,8 @@ RUN wget -O /usr/share/keyrings/element-io-archive-keyring.gpg https://packages.
 # Install signal-desktop
 RUN wget -O- https://updates.signal.org/desktop/apt/keys.asc | gpg --dearmor > /usr/share/keyrings/signal-desktop-keyring.gpg \
     && echo 'deb [arch=amd64 signed-by=/usr/share/keyrings/signal-desktop-keyring.gpg] https://updates.signal.org/desktop/apt xenial main' > /etc/apt/sources.list.d/signal-xenial.list \
-    && apt-get update && apt-get install -y signal-desktop && apt-get clean && rm -rf /var/lib/apt/lists/*
+    && apt-get -o Acquire::CompressionTypes::Order::=xz update \
+    && apt-get install -y signal-desktop && apt-get clean && rm -rf /var/lib/apt/lists/*
 
 # Install browsers and editors
 RUN mkdir -p /etc/apt/keyrings \


### PR DESCRIPTION
## Summary
- ensure `apt-get update` fetches Signal package index using `xz` compression

## Testing
- `apt-get update -o Acquire::CompressionTypes::Order::=xz`
- `apt-get install -y signal-desktop`


------
https://chatgpt.com/codex/tasks/task_b_6893cc90b478832f8b01bc90e061b44a