### PR TITLE
Fix: Add Opera repository to Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -107,6 +107,8 @@ RUN wget -O- https://updates.signal.org/desktop/apt/keys.asc | gpg --dearmor > /
 RUN mkdir -p /etc/apt/keyrings \
     && wget -q -O - https://dl.google.com/linux/linux_signing_key.pub | gpg --dearmor | tee /etc/apt/keyrings/google-chrome.gpg > /dev/null \
     && echo "deb [arch=$(dpkg --print-architecture) signed-by=/etc/apt/keyrings/google-chrome.gpg] http://dl.google.com/linux/chrome/deb/ stable main" > /etc/apt/sources.list.d/google-chrome.list \
+    && wget -q -O - https://deb.opera.com/archive.key | gpg --dearmor | tee /etc/apt/keyrings/opera.gpg > /dev/null \
+    && echo "deb [signed-by=/etc/apt/keyrings/opera.gpg] https://deb.opera.com/opera-stable/ stable non-free" > /etc/apt/sources.list.d/opera.list \
     && apt-get update \
     && apt-get install -y \
         google-chrome-stable brave-browser opera-stable code \


### PR DESCRIPTION
The Docker build was failing because the `opera-stable` package could not be found. This was because the Opera APT repository was not added to the system.

This change adds the necessary commands to the Dockerfile to add the Opera GPG key and repository before attempting to install the package. This follows the same pattern used for other browsers in the Dockerfile.