### PR TITLE
Add create-novnc homepage script

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -178,6 +178,7 @@ COPY fix-permissions.sh /usr/local/bin/fix-permissions.sh
 COPY test-polkit.sh /usr/local/bin/test-polkit.sh
 COPY create-virtual-pipewire-devices.sh /usr/local/bin/create-virtual-pipewire-devices.sh
 COPY fix-pipewire-routing.sh /usr/local/bin/fix-pipewire-routing.sh
+COPY create-novnc-homepage.sh /usr/local/bin/create-novnc-homepage.sh
 COPY setup-universal-audio.sh /usr/local/bin/setup-universal-audio.sh
 COPY wait-for-service.sh /usr/local/bin/wait-for-service.sh
 COPY supervisord-audio-fix.conf /etc/supervisor/conf.d/pipewire.conf
@@ -192,7 +193,8 @@ RUN chmod +x /usr/local/bin/setup-*.sh \
     /usr/local/bin/test-polkit.sh \
     /usr/local/bin/fix-pipewire-startup.sh \
     /usr/local/bin/create-virtual-pipewire-devices.sh \
-    /usr/local/bin/fix-pipewire-routing.sh
+    /usr/local/bin/fix-pipewire-routing.sh \
+    /usr/local/bin/create-novnc-homepage.sh
 
 # Initialize PipeWire system during build
 RUN /usr/local/bin/setup-pipewire.sh && \

--- a/create-novnc-homepage.sh
+++ b/create-novnc-homepage.sh
@@ -606,6 +606,3 @@ echo "🔧 Next steps:"
 echo "  1. Restart your Docker container to apply port changes"
 echo "  2. Run audio diagnostics: docker exec <container> /usr/local/bin/audio-validation.sh"
 echo "  3. Test WebRTC pipeline: docker exec <container> /usr/local/bin/test-webrtc-pipeline.sh"
-EOF
-
-chmod +x create-novnc-homepage.sh


### PR DESCRIPTION
## Summary
- copy create-novnc-homepage.sh into /usr/local/bin and mark executable
- clean up script end so entrypoint can run it

## Testing
- `bash create-novnc-homepage.sh`
- `timeout 15s bash entrypoint.sh`

------
https://chatgpt.com/codex/tasks/task_b_6893f450b674832f83eee7a78d992d8c