### PR TITLE
Run PipeWire services as dev user

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -381,6 +381,14 @@ case "$ANDROID_STATUS" in
         ;;
 esac
 
+# Ensure runtime directory for the development user exists
+if [ ! -d "/run/user/${DEV_UID}" ]; then
+    log_info "Creating XDG_RUNTIME_DIR for ${DEV_USERNAME}"
+    mkdir -p "/run/user/${DEV_UID}"
+    chown "${DEV_UID}:${DEV_GID}" "/run/user/${DEV_UID}"
+    chmod 700 "/run/user/${DEV_UID}"
+fi
+
 log_info "Starting supervisor daemon..."
 
 exec env \

--- a/supervisord-audio-fix.conf
+++ b/supervisord-audio-fix.conf
@@ -6,8 +6,8 @@ user=root
 command=/usr/bin/pipewire
 autostart=true
 autorestart=true
-user=root
-environment=HOME=/root,XDG_RUNTIME_DIR=/run/user/0
+user=%(ENV_DEV_USERNAME)s
+environment=HOME=/home/%(ENV_DEV_USERNAME)s,XDG_RUNTIME_DIR=/run/user/%(ENV_DEV_UID)s
 priority=10
 startretries=10
 startsecs=10
@@ -19,8 +19,8 @@ stderr_logfile=/var/log/supervisor/pipewire.log
 command=/usr/bin/wireplumber
 autostart=true
 autorestart=true
-user=root
-environment=HOME=/root,XDG_RUNTIME_DIR=/run/user/0
+user=%(ENV_DEV_USERNAME)s
+environment=HOME=/home/%(ENV_DEV_USERNAME)s,XDG_RUNTIME_DIR=/run/user/%(ENV_DEV_UID)s
 priority=15
 startretries=10
 startsecs=10


### PR DESCRIPTION
## Summary
- Run PipeWire and WirePlumber under DEV_USERNAME with proper HOME and XDG_RUNTIME_DIR
- Create /run/user/DEV_UID before starting supervisor to avoid runtime errors

## Testing
- `node --test test/audio-bridge.test.cjs`


------
https://chatgpt.com/codex/tasks/task_b_6893f5ee4ff8832f9c8bbc05860a1c6f