### PR TITLE
Wait for PipeWire before creating virtual devices

### DIFF
--- a/supervisord-audio-fix.conf
+++ b/supervisord-audio-fix.conf
@@ -32,11 +32,11 @@ stderr_logfile=/var/log/supervisor/wireplumber.log
 [program:create-virtual-devices]
 command=/usr/local/bin/create-virtual-pipewire-devices.sh
 autostart=true
-autorestart=false
+autorestart=unexpected
 user=root
 priority=20
-startsecs=5
-startretries=3
+startsecs=0
+startretries=10
 depends_on=wireplumber
 stdout_logfile=/var/log/supervisor/pipewire-devices.log
 stderr_logfile=/var/log/supervisor/pipewire-devices.log


### PR DESCRIPTION
## Summary
- wait for `pw-cli info` to succeed before creating PipeWire virtual devices
- retry virtual device creation under supervisord until PipeWire is ready

## Testing
- `bash -n create-virtual-pipewire-devices.sh`
- `PIPEWIRE_WAIT_TIMEOUT=1 bash create-virtual-pipewire-devices.sh`
- `supervisord --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_b_6893f767e984832f87f5e676b665da94