### PR TITLE
Add Anbox setup script and confirm Waydroid fallback

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -166,6 +166,7 @@ COPY setup-marketing-shortcuts.sh /usr/local/bin/setup-marketing-shortcuts.sh
 COPY setup-development.sh /usr/local/bin/setup-development.sh
 COPY setup-wine.sh /usr/local/bin/setup-wine.sh
 COPY setup-waydroid.sh /usr/local/bin/setup-waydroid.sh
+COPY setup-anbox.sh /usr/local/bin/setup-anbox.sh
 COPY setup-video-editing.sh /usr/local/bin/setup-video-editing.sh
 COPY setup-ttyd.sh /usr/local/bin/setup-ttyd.sh
 COPY service-health.sh /usr/local/bin/service-health.sh


### PR DESCRIPTION
## Summary
- Copy `setup-anbox.sh` into `/usr/local/bin` alongside existing setup scripts
- Use wildcard `chmod` to mark setup scripts executable, removing the redundant explicit entry for `setup-anbox.sh`
- Ensure Waydroid setup falls back to Anbox when kernel modules are missing

## Testing
- `npm test` *(fails: could not read package.json)*
- `DEV_USERNAME=root bash setup-waydroid.sh 2>&1 | head -n 80` *(shows `Attempting Anbox fallback` when kernel modules are missing)*

------
https://chatgpt.com/codex/tasks/task_b_6893f8f2beec832f8a56c98f188332bb