### PR TITLE
Fix duplicate TTYD setup log

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -240,7 +240,6 @@ echo "✅ D-Bus directories prepared"
 log_info "Setting up TTYD terminal service..."
 if [ -f "/usr/local/bin/setup-ttyd.sh" ]; then
     /usr/local/bin/setup-ttyd.sh
-    echo "✅ TTYD setup completed"
 else
     echo "⚠️  TTYD setup script not found"
 fi


### PR DESCRIPTION
## Summary
- prevent TTYD setup from logging completion twice

## Testing
- `bash -n entrypoint.sh`
- `bash -n setup-ttyd.sh`
- `bash entrypoint.sh >/tmp/entrypoint.log && grep -c "TTYD setup completed" /tmp/entrypoint.log`

------
https://chatgpt.com/codex/tasks/task_b_6893fbe2b624832fb2cdf88e85cbdd81