### PR TITLE
docs: document host modules for Waydroid support

### DIFF
--- a/TROUBLESHOOTING.md
+++ b/TROUBLESHOOTING.md
@@ -266,6 +266,27 @@ docker exec webtop-kde curl -I http://localhost:80
 docker exec webtop-kde curl -I http://localhost:7681
 ```
 
+### 🤖 Android Support Issues
+
+#### Waydroid skipped due to missing kernel modules
+**Cause**: The Docker host is missing the `binder_linux` and `ashmem_linux` kernel modules required by Waydroid.
+
+**Solution**:
+```bash
+# Load required modules on the Docker host
+sudo modprobe binder_linux
+sudo modprobe ashmem_linux
+
+# Ensure modules load at boot
+echo binder_linux | sudo tee -a /etc/modules
+echo ashmem_linux | sudo tee -a /etc/modules
+
+# Restart the container to allow Waydroid setup
+./webtop.sh restart
+```
+
+Without these modules, Android support is skipped and the setup may fall back to Anbox.
+
 ## Recovery Procedures
 
 ### Complete Service Reset


### PR DESCRIPTION
## Summary
- add Android support troubleshooting section detailing binder_linux and ashmem_linux module requirements
- document commands to load modules, persist them, and restart the container to enable Waydroid
- note that missing modules disable Waydroid and fall back to Anbox

## Testing
- `./test-polkit.sh` *(fails: D-Bus is not running)*

------
https://chatgpt.com/codex/tasks/task_b_6893fdaf6cf4832fb10ce8c619744414