### PR TITLE
Quote environment variable values in supervisor config

### DIFF
--- a/supervisord-audio-fix.conf
+++ b/supervisord-audio-fix.conf
@@ -7,7 +7,7 @@ command=/bin/bash -c "export XDG_RUNTIME_DIR=/run/user/%(ENV_DEV_UID)s && export
 autostart=true
 autorestart=true
 user=%(ENV_DEV_USERNAME)s
-environment=HOME=/home/%(ENV_DEV_USERNAME)s,XDG_RUNTIME_DIR=/run/user/%(ENV_DEV_UID)s,PIPEWIRE_RUNTIME_DIR=/run/user/%(ENV_DEV_UID)s/pipewire,DBUS_SESSION_BUS_ADDRESS=unix:path=/run/user/%(ENV_DEV_UID)s/bus
+environment=HOME="/home/%(ENV_DEV_USERNAME)s",XDG_RUNTIME_DIR="/run/user/%(ENV_DEV_UID)s",PIPEWIRE_RUNTIME_DIR="/run/user/%(ENV_DEV_UID)s/pipewire",DBUS_SESSION_BUS_ADDRESS="unix:path=/run/user/%(ENV_DEV_UID)s/bus"
 priority=10
 startretries=3
 startsecs=5
@@ -20,7 +20,7 @@ command=/bin/bash -c "sleep 3 && export XDG_RUNTIME_DIR=/run/user/%(ENV_DEV_UID)
 autostart=true
 autorestart=true
 user=%(ENV_DEV_USERNAME)s
-environment=HOME=/home/%(ENV_DEV_USERNAME)s,XDG_RUNTIME_DIR=/run/user/%(ENV_DEV_UID)s,DBUS_SESSION_BUS_ADDRESS=unix:path=/run/user/%(ENV_DEV_UID)s/bus
+environment=HOME="/home/%(ENV_DEV_USERNAME)s",XDG_RUNTIME_DIR="/run/user/%(ENV_DEV_UID)s",DBUS_SESSION_BUS_ADDRESS="unix:path=/run/user/%(ENV_DEV_UID)s/bus"
 priority=15
 startretries=3
 startsecs=8


### PR DESCRIPTION
## Summary
- quote environment variable values in supervisor pipewire config

## Testing
- `supervisord -c /etc/supervisor/conf.d/pipewire.conf`
- `npm test` *(fails: Missing script: "test")*

------
https://chatgpt.com/codex/tasks/task_b_689488229f58832fbc40aed740a27178