### PR TITLE
fix: avoid duplicate Opera apt sources

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -108,6 +108,9 @@ RUN mkdir -p /etc/apt/keyrings \
     && wget -q -O - https://dl.google.com/linux/linux_signing_key.pub | gpg --dearmor | tee /etc/apt/keyrings/google-chrome.gpg > /dev/null \
     && echo "deb [arch=$(dpkg --print-architecture) signed-by=/etc/apt/keyrings/google-chrome.gpg] http://dl.google.com/linux/chrome/deb/ stable main" > /etc/apt/sources.list.d/google-chrome.list \
     && wget -q -O - https://deb.opera.com/archive.key | gpg --dearmor | tee /etc/apt/keyrings/opera.gpg > /dev/null \
+    && if find /etc/apt/sources.list.d -maxdepth 1 -type f -name "*opera*" | grep -q .; then \
+        rm -f /etc/apt/sources.list.d/*opera*; \
+    fi \
     && echo "deb [signed-by=/etc/apt/keyrings/opera.gpg] https://deb.opera.com/opera-stable/ stable non-free" > /etc/apt/sources.list.d/opera.list \
     && apt-get update \
     && apt-get install -y \


### PR DESCRIPTION
## Summary
- replace any existing Opera repo files before adding our own

## Testing
- `apt-get update` after simulating a duplicate repo showed no warnings
- `dockerd --storage-driver=fuse-overlayfs` *(fails: Error initializing network controller: iptables permission denied)*

------
https://chatgpt.com/codex/tasks/task_b_689489a10e1c832fb0015db0f2da6d80