### PR TITLE
Fix supervisor PipeWire configuration for noVNC startup

### DIFF
--- a/supervisord-audio-fix.conf
+++ b/supervisord-audio-fix.conf
@@ -3,11 +3,11 @@ nodaemon=true
 user=root
 
 [program:pipewire]
-command=/bin/bash -c "export XDG_RUNTIME_DIR=/run/user/%(ENV_DEV_UID)s && export PIPEWIRE_RUNTIME_DIR=$XDG_RUNTIME_DIR/pipewire && mkdir -p $PIPEWIRE_RUNTIME_DIR && /usr/bin/pipewire"
+command=/bin/bash -c "export XDG_RUNTIME_DIR=/run/user/%(ENV_DEV_UID)s && export PIPEWIRE_RUNTIME_DIR=$XDG_RUNTIME_DIR/pipewire && export DBUS_SESSION_BUS_ADDRESS=unix:path=/run/user/%(ENV_DEV_UID)s/bus && mkdir -p $PIPEWIRE_RUNTIME_DIR && /usr/bin/pipewire"
 autostart=true
 autorestart=true
 user=%(ENV_DEV_USERNAME)s
-environment=HOME="/home/%(ENV_DEV_USERNAME)s",XDG_RUNTIME_DIR="/run/user/%(ENV_DEV_UID)s",PIPEWIRE_RUNTIME_DIR="/run/user/%(ENV_DEV_UID)s/pipewire",DBUS_SESSION_BUS_ADDRESS="unix:path=/run/user/%(ENV_DEV_UID)s/bus"
+environment=HOME="/home/%(ENV_DEV_USERNAME)s",XDG_RUNTIME_DIR="/run/user/%(ENV_DEV_UID)s",PIPEWIRE_RUNTIME_DIR="/run/user/%(ENV_DEV_UID)s/pipewire"
 priority=10
 startretries=3
 startsecs=5
@@ -16,11 +16,11 @@ stdout_logfile=/var/log/supervisor/pipewire.log
 stderr_logfile=/var/log/supervisor/pipewire.log
 
 [program:wireplumber]
-command=/bin/bash -c "sleep 3 && export XDG_RUNTIME_DIR=/run/user/%(ENV_DEV_UID)s && /usr/bin/wireplumber"
+command=/bin/bash -c "sleep 3 && export XDG_RUNTIME_DIR=/run/user/%(ENV_DEV_UID)s && export DBUS_SESSION_BUS_ADDRESS=unix:path=/run/user/%(ENV_DEV_UID)s/bus && /usr/bin/wireplumber"
 autostart=true
 autorestart=true
 user=%(ENV_DEV_USERNAME)s
-environment=HOME="/home/%(ENV_DEV_USERNAME)s",XDG_RUNTIME_DIR="/run/user/%(ENV_DEV_UID)s",DBUS_SESSION_BUS_ADDRESS="unix:path=/run/user/%(ENV_DEV_UID)s/bus"
+environment=HOME="/home/%(ENV_DEV_USERNAME)s",XDG_RUNTIME_DIR="/run/user/%(ENV_DEV_UID)s"
 priority=15
 startretries=3
 startsecs=8


### PR DESCRIPTION
## Summary
- ensure PipeWire and WirePlumber set DBUS_SESSION_BUS_ADDRESS within command instead of supervisor `environment`
- drop problematic DBUS entry from `environment` to avoid parse errors and allow supervisor to start services

## Testing
- `npm test` *(fails: Missing script)*
- `node test/audio-bridge.test.cjs`


------
https://chatgpt.com/codex/tasks/task_b_68948962edf8832f921bd9b6fb01c7b5