### PR TITLE
Include add-user-session script in Docker image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -185,6 +185,7 @@ COPY fix-pipewire-routing.sh /usr/local/bin/fix-pipewire-routing.sh
 COPY create-novnc-homepage.sh /usr/local/bin/create-novnc-homepage.sh
 COPY setup-universal-audio.sh /usr/local/bin/setup-universal-audio.sh
 COPY wait-for-service.sh /usr/local/bin/wait-for-service.sh
+COPY add-user-session.sh /usr/local/bin/add-user-session.sh
 COPY supervisord-audio-fix.conf /etc/supervisor/conf.d/pipewire.conf
 RUN chmod +x /usr/local/bin/setup-*.sh \
     /usr/local/bin/setup-anbox.sh \
@@ -199,7 +200,8 @@ RUN chmod +x /usr/local/bin/setup-*.sh \
     /usr/local/bin/fix-pipewire-startup.sh \
     /usr/local/bin/create-virtual-pipewire-devices.sh \
     /usr/local/bin/fix-pipewire-routing.sh \
-    /usr/local/bin/create-novnc-homepage.sh
+    /usr/local/bin/create-novnc-homepage.sh \
+    /usr/local/bin/add-user-session.sh
 
 # Initialize PipeWire system during build
 RUN /usr/local/bin/setup-pipewire.sh && \


### PR DESCRIPTION
## Summary
- ensure add-user-session.sh is installed and executable in the container
- allow entrypoint to configure VNC and noVNC ports

## Testing
- `npm ci`
- `node test/audio-bridge.test.cjs`

------
https://chatgpt.com/codex/tasks/task_b_6894a9b02064832fb2a9592c2c7388ae