### PR TITLE
Fix PipeWire setup user vars and Opera repo duplication

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -108,7 +108,7 @@ RUN mkdir -p /etc/apt/keyrings \
     && wget -q -O - https://dl.google.com/linux/linux_signing_key.pub | gpg --dearmor | tee /etc/apt/keyrings/google-chrome.gpg > /dev/null \
     && echo "deb [arch=$(dpkg --print-architecture) signed-by=/etc/apt/keyrings/google-chrome.gpg] http://dl.google.com/linux/chrome/deb/ stable main" > /etc/apt/sources.list.d/google-chrome.list \
     && wget -q -O - https://deb.opera.com/archive.key | gpg --dearmor | tee /etc/apt/keyrings/opera.gpg > /dev/null \
-    && echo "deb [signed-by=/etc/apt/keyrings/opera.gpg] https://deb.opera.com/opera-stable/ stable non-free" > /etc/apt/sources.list.d/opera.list \
+    && echo "deb [signed-by=/etc/apt/keyrings/opera.gpg] https://deb.opera.com/opera-stable/ stable non-free" > /etc/apt/sources.list.d/opera-stable.list \
     && apt-get update \
     && apt-get install -y \
         google-chrome-stable brave-browser opera-stable code \

--- a/setup-pipewire.sh
+++ b/setup-pipewire.sh
@@ -25,7 +25,7 @@ context.properties = {
     link.max-buffers         = 64
     log.level                = 2
     core.daemon              = true
-    core.name                = pipewire-\${uid}
+    core.name                = pipewire-${uid}
 }
 
 context.spa-libs = {
@@ -49,15 +49,15 @@ EOF
 configure_user() {
     local user="$1" uid="$2" home="$3"
 
-    mkdir -p "/run/user/\${uid}/pipewire"
-    chown "\${user}:\${user}" "/run/user/\${uid}" "/run/user/\${uid}/pipewire"
-    chmod 700 "/run/user/\${uid}"
+    mkdir -p "/run/user/${uid}/pipewire"
+    chown "${user}:${user}" "/run/user/${uid}" "/run/user/${uid}/pipewire"
+    chmod 700 "/run/user/${uid}"
 
-    mkdir -p "\${home}/.config/pipewire"
-    generate_user_pipewire_conf "\${uid}" > "\${home}/.config/pipewire/pipewire.conf"
-    chown -R "\${user}:\${user}" "\${home}/.config"
+    mkdir -p "${home}/.config/pipewire"
+    generate_user_pipewire_conf "${uid}" > "${home}/.config/pipewire/pipewire.conf"
+    chown -R "${user}:${user}" "${home}/.config"
 
-    cat <<EOF > "\${home}/.asoundrc"
+    cat <<EOF > "${home}/.asoundrc"
 # User ALSA configuration for PipeWire
 pcm.!default {
     type pipewire
@@ -69,7 +69,7 @@ ctl.!default {
     type pipewire
 }
 EOF
-    chown "\${user}:\${user}" "\${home}/.asoundrc"
+    chown "${user}:${user}" "${home}/.asoundrc"
 }
 
 # Create PipeWire system configuration


### PR DESCRIPTION
## Summary
- correct variable expansion in `setup-pipewire.sh` so user configuration works at build time
- use a single Opera APT source file to avoid duplicate repository warnings

## Testing
- `bash -n setup-pipewire.sh`
- `node --test test/audio-bridge.test.cjs`


------
https://chatgpt.com/codex/tasks/task_b_6894b6f834ac832f9ddde3cf86d62426