### PR TITLE
Ensure PipeWire starts its own D-Bus session

### DIFF
--- a/SERVICES.md
+++ b/SERVICES.md
@@ -32,6 +32,12 @@ Container-compatible audio infrastructure.
 - **Configuration**: Uses virtual sinks for container compatibility
 - **Critical**: Yes - Required for audio functionality
 
+#### PipeWireStartup (Utility)
+- **Purpose**: Prepares runtime audio environment and validates D-Bus availability
+- **Behavior**: Launches a session D-Bus via `dbus-daemon` if none is running and aborts when the bus cannot be started
+- **Script**: `fix-pipewire-startup.sh`
+- **Critical**: Yes - Ensures reliable PipeWire initialization
+
 #### AudioValidation (Priority 28)
 - **Purpose**: Creates and validates virtual audio devices
 - **Dependencies**: PipeWire

--- a/fix-pipewire-startup.sh
+++ b/fix-pipewire-startup.sh
@@ -54,8 +54,13 @@ main() {
 
     # 3. Ensure a D-Bus session is available before starting services
     if ! pgrep -x dbus-daemon >/dev/null 2>&1; then
-        yellow "⚠️ D-Bus session not running. Skipping PipeWire startup."
-        return 0
+        blue "🔄 Starting D-Bus session..."
+        if ! DBUS_SESSION_BUS_ADDRESS="$(dbus-daemon --session --fork --print-address 2>/dev/null)"; then
+            red "❌ Unable to start D-Bus session. Aborting PipeWire startup."
+            return 1
+        fi
+        export DBUS_SESSION_BUS_ADDRESS
+        green "✅ D-Bus session started."
     fi
 
     # 4. Start PipeWire and WirePlumber services


### PR DESCRIPTION
## Summary
- Start a private D-Bus session when none is running before launching PipeWire
- Document the new D-Bus startup behavior for PipeWire maintainers

## Testing
- `shellcheck fix-pipewire-startup.sh`
- `bash -n fix-pipewire-startup.sh`


------
https://chatgpt.com/codex/tasks/task_b_6894ce646fc0832f88153e4df3ea0277