### PR TITLE
Manage audio services separately

### DIFF
--- a/supervisord.conf
+++ b/supervisord.conf
@@ -45,16 +45,6 @@ startretries=5
 stdout_logfile=/var/log/supervisor/accounts-daemon.log
 stderr_logfile=/var/log/supervisor/accounts-daemon.log
 
-[program:audio_session]
-command=/usr/local/bin/start-audio-session.sh
-priority=25
-autostart=true
-autorestart=true
-user=%(ENV_DEV_USERNAME)s
-environment=DEV_USERNAME=%(ENV_DEV_USERNAME)s,DEV_UID=%(ENV_DEV_UID)s,DEV_GID=%(ENV_DEV_GID)s,XDG_RUNTIME_DIR=/run/user/%(ENV_DEV_UID)s
-stdout_logfile=/var/log/supervisor/audio_session.log
-stderr_logfile=/var/log/supervisor/audio_session.log
-
 [program:KDE]
 command=/bin/sh -c "sleep 15; export DISPLAY=:1; export XDG_RUNTIME_DIR=/run/user/%(ENV_DEV_UID)s; export HOME=/home/%(ENV_DEV_USERNAME)s; exec startplasma-x11"
 priority=30
@@ -165,6 +155,7 @@ programs=Xvfb,dbus,accounts-daemon
 priority=10
 
 [include]
+; Load additional service definitions (pipewire, wireplumber, virtual devices)
 files = /etc/supervisor/conf.d/*.conf
 
 [program:ServiceRecoveryManager]


### PR DESCRIPTION
## Summary
- remove legacy `audio_session` supervisor program
- load `pipewire`, `wireplumber`, and virtual device setup via included config
- document `group:audio` workflow and restart commands

## Testing
- `node test/audio-bridge.test.cjs`


------
https://chatgpt.com/codex/tasks/task_b_6894cf84a9ec832fbe8696e315f8991f