### PR TITLE
Ensure PipeWire runtime persists across restarts

### DIFF
--- a/README_AUDIO.md
+++ b/README_AUDIO.md
@@ -12,13 +12,21 @@ This WebTop includes a comprehensive PipeWire-based audio system with WebRTC str
 
 ## Host Setup
 
-The container relies on an ALSA loopback device provided by the host. Before
-starting the WebTop container, make sure the module is loaded:
+The container relies on host sound modules and device mappings.
+
+### Required kernel modules
+
+Load the ALSA loopback module before starting the WebTop container:
 
 ```bash
 sudo modprobe snd-aloop
 echo snd-aloop | sudo tee -a /etc/modules
 ```
+
+### Device mapping
+
+Expose the host sound devices by mapping `/dev/snd` into the container. This
+is handled in `docker-compose.yml` under the `devices` section.
 
 These steps ensure the audio system has the necessary devices when the container starts.
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -17,6 +17,9 @@ services:
       - "8081:8081"     # WebRTC signaling WebSocket
     env_file:
       - .env
+    environment:
+      PIPEWIRE_RUNTIME_DIR: /run/user/${DEV_UID}
+      XDG_RUNTIME_DIR: /run/user/${DEV_UID}
     volumes:
       - /data/ubuntu-kde-docker_webtop/config:/config
       - /data/ubuntu-kde-docker_webtop/var/log/supervisor:/var/log/supervisor

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -223,11 +223,13 @@ XEOF
 chown -R "${DEV_USERNAME}":"${DEV_USERNAME}" "/home/${DEV_USERNAME}/.vnc"
 chmod +x "/home/${DEV_USERNAME}/.vnc/xstartup"
 
-# XDG runtime directory
+# Recreate XDG runtime directory and PipeWire sockets
+rm -rf "/run/user/${DEV_UID}"
 mkdir -p "/run/user/${DEV_UID}"
 chown "${DEV_USERNAME}":"${DEV_USERNAME}" "/run/user/${DEV_UID}"
 chmod 700 "/run/user/${DEV_UID}"
 export XDG_RUNTIME_DIR="/run/user/${DEV_UID}"
+export PIPEWIRE_RUNTIME_DIR="/run/user/${DEV_UID}"
 
 echo "🔧 Preparing D-Bus directories..."
 mkdir -p /run/dbus


### PR DESCRIPTION
## Summary
- ensure audio processes use a consistent `/run/user` path via `PIPEWIRE_RUNTIME_DIR` and `XDG_RUNTIME_DIR`
- recreate `/run/user/<uid>` at startup to avoid stale PipeWire sockets
- document host requirements for kernel modules and `/dev/snd` mapping

## Testing
- `node test/audio-bridge.test.cjs` *(fails: required binary 'gst-launch-1.0' not found)*

------
https://chatgpt.com/codex/tasks/task_b_6894d60a4d54832fa836b8c6c91dfe8f