### PR TITLE
Move PipeWire setup to runtime

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -198,9 +198,6 @@ RUN chmod +x /usr/local/bin/setup-*.sh \
     /usr/local/bin/fix-pipewire-routing.sh \
     /usr/local/bin/create-novnc-homepage.sh
 
-# Initialize PipeWire system during build
-RUN /usr/local/bin/setup-pipewire.sh && \
-    /usr/local/bin/fix-pipewire-startup.sh
 
 # Run TTYD setup to create wrapper script
 RUN /usr/local/bin/setup-ttyd.sh

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -236,7 +236,20 @@ mkdir -p /run/dbus
 echo "✅ D-Bus directories prepared"
 
 # Set up audio system before other services
+# Initialize PipeWire and apply startup fixes
+log_info "Setting up PipeWire audio system..."
+if [ -f "/usr/local/bin/setup-pipewire.sh" ]; then
+    /usr/local/bin/setup-pipewire.sh
+else
+    log_warn "setup-pipewire.sh script not found"
+fi
 
+log_info "Applying PipeWire startup fixes..."
+if [ -f "/usr/local/bin/fix-pipewire-startup.sh" ]; then
+    /usr/local/bin/fix-pipewire-startup.sh
+else
+    log_warn "fix-pipewire-startup.sh script not found"
+fi
 
 # Set up TTYD terminal service
 log_info "Setting up TTYD terminal service..."


### PR DESCRIPTION
## Summary
- stop running PipeWire setup during image build
- initialize PipeWire and apply startup fix scripts in entrypoint at container startup

## Testing
- `bash -n entrypoint.sh`
- `apt-get install -y pipewire wireplumber supervisor`
- `./setup-pipewire.sh`
- `./fix-pipewire-startup.sh` *(fails: pipewire/wireplumber exited unexpectedly)*
- `apt-get install -y docker.io`
- `docker build -t test-image .` *(fails: Cannot connect to Docker daemon)*

------
https://chatgpt.com/codex/tasks/task_b_6894d9078540832f8ab209a18c1638b9