### PR TITLE
Safely forward arguments in PipeWire helpers

### DIFF
--- a/create-virtual-pipewire-devices.sh
+++ b/create-virtual-pipewire-devices.sh
@@ -29,18 +29,22 @@ PIPEWIRE_WAIT_TIMEOUT="${PIPEWIRE_WAIT_TIMEOUT:-30}"
 # Function to execute PipeWire commands
 run_pw_cli() {
     if [ "$DEV_USERNAME" = "root" ]; then
-        pw-cli "$@"
+        pw-cli "${@}"
     else
-        su - "${DEV_USERNAME}" -c "export XDG_RUNTIME_DIR=/run/user/${DEV_UID}; pw-cli $*"
+        local cmd
+        cmd="export XDG_RUNTIME_DIR=/run/user/${DEV_UID}; pw-cli $(printf '%q ' "$@")"
+        su - "${DEV_USERNAME}" -c "$cmd"
     fi
 }
 
 # Function to execute wpctl commands
 run_wpctl() {
     if [ "$DEV_USERNAME" = "root" ]; then
-        wpctl "$@"
+        wpctl "${@}"
     else
-        su - "${DEV_USERNAME}" -c "export XDG_RUNTIME_DIR=/run/user/${DEV_UID}; wpctl $*"
+        local cmd
+        cmd="export XDG_RUNTIME_DIR=/run/user/${DEV_UID}; wpctl $(printf '%q ' "$@")"
+        su - "${DEV_USERNAME}" -c "$cmd"
     fi
 }
 

--- a/create-virtual-pipewire-devices.sh.bak
+++ b/create-virtual-pipewire-devices.sh.bak
@@ -15,35 +15,31 @@ echo "🔊 Creating virtual PipeWire audio devices..."
 
 # Function to execute PipeWire commands with fallback
 run_pw_cli() {
-    local cmd="$1"
-    
     # Try as the user first
-    if su - "${DEV_USERNAME}" -c "export XDG_RUNTIME_DIR=/run/user/${DEV_UID}; pw-cli $cmd" 2>/dev/null; then
+    if su - "${DEV_USERNAME}" -c "export XDG_RUNTIME_DIR=/run/user/${DEV_UID}; pw-cli $(printf '%q ' "$@")" 2>/dev/null; then
         return 0
     fi
-    
+
     # Fallback: try direct execution
-    if pw-cli "$cmd" 2>/dev/null; then
+    if pw-cli "${@}" 2>/dev/null; then
         return 0
     fi
-    
+
     return 1
 }
 
 # Function to execute WirePlumber commands
 run_wpctl() {
-    local cmd="$1"
-    
     # Try as the user first
-    if su - "${DEV_USERNAME}" -c "export XDG_RUNTIME_DIR=/run/user/${DEV_UID}; wpctl $cmd" 2>/dev/null; then
+    if su - "${DEV_USERNAME}" -c "export XDG_RUNTIME_DIR=/run/user/${DEV_UID}; wpctl $(printf '%q ' "$@")" 2>/dev/null; then
         return 0
     fi
-    
+
     # Fallback: try direct execution
-    if wpctl "$cmd" 2>/dev/null; then
+    if wpctl "${@}" 2>/dev/null; then
         return 0
     fi
-    
+
     return 1
 }
 


### PR DESCRIPTION
## Summary
- escape arguments when invoking `pw-cli` or `wpctl` via `su` so descriptions with spaces are preserved
- keep the root branch using `"${@}"`

## Testing
- `apt-get install -y pipewire wireplumber`
- `bash create-virtual-pipewire-devices.sh` *(fails to set default devices: `virtual_speaker not found`)*

------
https://chatgpt.com/codex/tasks/task_b_6894daf237a8832fa8509661f7c85bd9