### PR TITLE
Harden virtual device supervisor startup

### DIFF
--- a/supervisord-audio-fix.conf
+++ b/supervisord-audio-fix.conf
@@ -30,13 +30,13 @@ stdout_logfile=/var/log/supervisor/wireplumber.log
 stderr_logfile=/var/log/supervisor/wireplumber.log
 
 [program:create-virtual-devices]
-command=/usr/local/bin/create-virtual-pipewire-devices.sh
+command=/usr/local/bin/wait-for-service.sh /run/user/%(ENV_DEV_UID)s/pipewire-0 /usr/local/bin/create-virtual-pipewire-devices.sh
 autostart=true
-autorestart=unexpected
+autorestart=false
 user=root
 priority=20
 startsecs=0
-startretries=10
+startretries=3
 depends_on=wireplumber
 stdout_logfile=/var/log/supervisor/pipewire-devices.log
 stderr_logfile=/var/log/supervisor/pipewire-devices.log


### PR DESCRIPTION
## Summary
- Wait for PipeWire socket before creating virtual devices
- Disable autorestart and lower retry count for virtual device creation

## Testing
- `supervisord -c /tmp/supervisord-test.conf` (fails after 3 retries)


------
https://chatgpt.com/codex/tasks/task_b_6894dce5fe1c832f96984c6d476d0c41