### PR TITLE
Handle root home path for audio services

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -201,6 +201,7 @@ usermod -aG sudo,ssl-cert,audio,video "$DEV_USERNAME"
 # Ensure runtime variables match the actual user IDs
 DEV_UID="$(id -u "$DEV_USERNAME")"
 DEV_GID="$(id -g "$DEV_USERNAME")"
+DEV_HOME="$(getent passwd "$DEV_USERNAME" | cut -d: -f6)"
 
 # Admin user
 if ! id -u "$ADMIN_USERNAME" > /dev/null 2>&1; then
@@ -409,8 +410,9 @@ exec env \
     ENV_DEV_USERNAME="${DEV_USERNAME}" \
     ENV_DEV_UID="${DEV_UID}" \
     ENV_DEV_GID="${DEV_GID}" \
+    ENV_DEV_HOME="${DEV_HOME}" \
     ENV_TTYD_USER="${TTYD_USER}" \
     ENV_TTYD_PASSWORD="${TTYD_PASSWORD}" \
-    DEV_USERNAME="${DEV_USERNAME}" DEV_UID="${DEV_UID}" DEV_GID="${DEV_GID}" \
+    DEV_USERNAME="${DEV_USERNAME}" DEV_UID="${DEV_UID}" DEV_GID="${DEV_GID}" DEV_HOME="${DEV_HOME}" \
     TTYD_USER="${TTYD_USER}" TTYD_PASSWORD="${TTYD_PASSWORD}" \
     /usr/bin/supervisord -c /etc/supervisor/supervisord.conf -n

--- a/fix-pipewire-startup.sh
+++ b/fix-pipewire-startup.sh
@@ -4,6 +4,7 @@ set -euo pipefail
 
 DEV_USERNAME="${DEV_USERNAME:-devuser}"
 DEV_UID="${DEV_UID:-$(id -u "$DEV_USERNAME" 2>/dev/null || echo 1000)}"
+DEV_HOME=""
 
 # Color output functions
 red() { echo -e "\033[31m$*\033[0m"; }
@@ -36,7 +37,9 @@ main() {
         DEV_USERNAME="root"
         DEV_UID=0
     fi
-    export DEV_USERNAME DEV_UID
+
+    DEV_HOME="$(getent passwd "$DEV_USERNAME" | cut -d: -f6 2>/dev/null || echo "/home/${DEV_USERNAME}")"
+    export DEV_USERNAME DEV_UID DEV_HOME
 
     # 1. Ensure runtime directories exist
     mkdir -p "/run/user/${DEV_UID}/pipewire"

--- a/setup-pipewire.sh
+++ b/setup-pipewire.sh
@@ -3,6 +3,7 @@ set -euo pipefail
 
 DEV_USERNAME="${DEV_USERNAME:-devuser}"
 DEV_UID="${DEV_UID:-$(id -u "$DEV_USERNAME" 2>/dev/null || echo 1000)}"
+DEV_HOME="$(getent passwd "$DEV_USERNAME" | cut -d: -f6 2>/dev/null || echo "/home/${DEV_USERNAME}")"
 
 echo "🔊 Setting up PipeWire audio system..."
 
@@ -111,8 +112,8 @@ EOF
 
 # Create user-specific PipeWire configuration (runtime only)
 if [ "$IS_RUNTIME" = true ]; then
-    mkdir -p "/home/${DEV_USERNAME}/.config/pipewire"
-    cat <<EOF > "/home/${DEV_USERNAME}/.config/pipewire/pipewire.conf"
+    mkdir -p "${DEV_HOME}/.config/pipewire"
+    cat <<EOF > "${DEV_HOME}/.config/pipewire/pipewire.conf"
 # User-specific PipeWire configuration
 context.properties = {
     default.clock.rate        = 44100
@@ -140,7 +141,7 @@ context.modules = [
 EOF
 
     # Set proper ownership (runtime only)
-    chown -R "${DEV_USERNAME}:${DEV_USERNAME}" "/home/${DEV_USERNAME}/.config"
+    chown -R "${DEV_USERNAME}:${DEV_USERNAME}" "${DEV_HOME}/.config"
 fi
 
 # Create ALSA configuration for PipeWire compatibility
@@ -182,7 +183,7 @@ EOF
 
 # Create user-specific ALSA configuration (runtime only)
 if [ "$IS_RUNTIME" = true ]; then
-    cat <<EOF > "/home/${DEV_USERNAME}/.asoundrc"
+    cat <<EOF > "${DEV_HOME}/.asoundrc"
 # User ALSA configuration for PipeWire
 pcm.!default {
     type pipewire
@@ -195,7 +196,7 @@ ctl.!default {
 }
 EOF
 
-    chown "${DEV_USERNAME}:${DEV_USERNAME}" "/home/${DEV_USERNAME}/.asoundrc"
+    chown "${DEV_USERNAME}:${DEV_USERNAME}" "${DEV_HOME}/.asoundrc"
 fi
 
 # Create PipeWire test script

--- a/supervisord-audio-fix.conf
+++ b/supervisord-audio-fix.conf
@@ -7,7 +7,7 @@ command=/usr/bin/pipewire
 autostart=true
 autorestart=true
 user=%(ENV_DEV_USERNAME)s
-environment=HOME=/home/%(ENV_DEV_USERNAME)s,XDG_RUNTIME_DIR=/run/user/%(ENV_DEV_UID)s
+environment=HOME=%(ENV_DEV_HOME)s,XDG_RUNTIME_DIR=/run/user/%(ENV_DEV_UID)s
 priority=10
 startretries=10
 startsecs=10
@@ -20,7 +20,7 @@ command=/usr/bin/wireplumber
 autostart=true
 autorestart=true
 user=%(ENV_DEV_USERNAME)s
-environment=HOME=/home/%(ENV_DEV_USERNAME)s,XDG_RUNTIME_DIR=/run/user/%(ENV_DEV_UID)s
+environment=HOME=%(ENV_DEV_HOME)s,XDG_RUNTIME_DIR=/run/user/%(ENV_DEV_UID)s
 priority=15
 startretries=10
 startsecs=10

--- a/supervisord.conf
+++ b/supervisord.conf
@@ -46,13 +46,13 @@ stdout_logfile=/var/log/supervisor/accounts-daemon.log
 stderr_logfile=/var/log/supervisor/accounts-daemon.log
 
 [program:KDE]
-command=/bin/sh -c "sleep 15; export DISPLAY=:1; export XDG_RUNTIME_DIR=/run/user/%(ENV_DEV_UID)s; export HOME=/home/%(ENV_DEV_USERNAME)s; exec startplasma-x11"
+command=/bin/sh -c "sleep 15; export DISPLAY=:1; export XDG_RUNTIME_DIR=/run/user/%(ENV_DEV_UID)s; export HOME=%(ENV_DEV_HOME)s; exec startplasma-x11"
 priority=30
 autostart=true
 autorestart=true
 stopsignal=TERM
 user=%(ENV_DEV_USERNAME)s
-environment=DISPLAY=:1,HOME=/home/%(ENV_DEV_USERNAME)s,USER=%(ENV_DEV_USERNAME)s,XDG_RUNTIME_DIR=/run/user/%(ENV_DEV_UID)s
+environment=DISPLAY=:1,HOME=%(ENV_DEV_HOME)s,USER=%(ENV_DEV_USERNAME)s,XDG_RUNTIME_DIR=/run/user/%(ENV_DEV_UID)s
 startsecs=15
 startretries=2
 stdout_logfile=/var/log/supervisor/kde.log


### PR DESCRIPTION
## Summary
- Export the actual home directory for the runtime user and pass it to supervisor-managed services
- Adjust PipeWire setup and startup scripts to respect the computed home directory
- Update supervisor configurations to use ENV_DEV_HOME for pipewire, wireplumber and KDE sessions

## Testing
- `./system-validation.sh --optimized` *(fails: supervisorctl: command not found; netstat: command not found)*

------
https://chatgpt.com/codex/tasks/task_b_6894e1decc30832fa79975a2ab115af9