### PR TITLE
Ensure node-pre-gyp installed before audio bridge dependencies

### DIFF
--- a/ubuntu-kde-docker/setup-audio-bridge.sh
+++ b/ubuntu-kde-docker/setup-audio-bridge.sh
@@ -30,6 +30,9 @@ cat > package.json << 'EOF'
 }
 EOF
 
+# Ensure node-pre-gyp is available for building native modules
+npm install node-pre-gyp
+
 # Install dependencies
 npm install
 


### PR DESCRIPTION
## Summary
- Guarantee node-pre-gyp is installed ahead of installing audio bridge dependencies to avoid wrtc build errors.

## Testing
- `shellcheck ubuntu-kde-docker/setup-audio-bridge.sh`
- `bash ubuntu-kde-docker/setup-audio-bridge.sh` (npm install succeeded)
- `npm test` *(fails: Cannot find package '@eslint/js')*
- `dockerd` *(fails: failed to start daemon: iptables permission denied)*

------
https://chatgpt.com/codex/tasks/task_b_6894fee80e2c832fbfdb301e463d7451