### PR TITLE
Install Node.js 18 once in Docker build and drop duplicate setup

### DIFF
--- a/ubuntu-kde-docker/Dockerfile
+++ b/ubuntu-kde-docker/Dockerfile
@@ -21,7 +21,6 @@ RUN apt-get update && apt-get install -y \
     krita blender darktable obs-studio calibre \
     git neofetch btop gnome-tweaks stacer \
     # Development Tools - Complete Stack (VS Code will be installed later)
-    nodejs npm yarn \
     python3 python3-pip python3-venv python3-dev jupyter-notebook \
     php php-cli php-fpm composer \
     ruby ruby-dev bundler golang-go \
@@ -73,9 +72,10 @@ RUN wget -qO- https://packages.microsoft.com/keys/microsoft.asc | gpg --dearmor 
     && echo "deb [arch=amd64 signed-by=/usr/share/keyrings/opera.gpg] https://deb.opera.com/opera-stable/ stable non-free" > /etc/apt/sources.list.d/opera.list \
     && apt-get update
 
-# Install Node.js 22 from NodeSource
-RUN curl -fsSL https://deb.nodesource.com/setup_22.x | bash - \
+# Install Node.js 18 LTS from NodeSource
+RUN curl -fsSL https://deb.nodesource.com/setup_18.x | bash - \
     && apt-get install -y nodejs \
+    && npm install -g yarn \
     && apt-get clean && rm -rf /var/lib/apt/lists/*
 
 # Packages required for WebRTC audio bridge

--- a/ubuntu-kde-docker/setup-audio-bridge.sh
+++ b/ubuntu-kde-docker/setup-audio-bridge.sh
@@ -7,10 +7,6 @@ set -e
 
 echo "Setting up PulseAudio Web Audio Bridge..."
 
-# Install Node.js and npm for the audio bridge
-curl -fsSL https://deb.nodesource.com/setup_18.x | bash -
-apt-get install -y nodejs
-
 # Create audio bridge directory
 mkdir -p /opt/audio-bridge
 cd /opt/audio-bridge


### PR DESCRIPTION
## Summary
- Standardize on Node.js 18 LTS in the Ubuntu KDE Docker image
- Remove redundant Node installation from audio bridge setup script

## Testing
- `setup-audio-bridge.sh`
- `node --version`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_b_6895017126cc832f8933d98d150dc64f