### PR TITLE
Expose STUN, VNC, and WebRTC ports in Docker Compose

### DIFF
--- a/ubuntu-kde-docker/docker-compose.dev.yml
+++ b/ubuntu-kde-docker/docker-compose.dev.yml
@@ -11,8 +11,11 @@ services:
       - "32768:80"      # noVNC
       - "2222:22"       # SSH
       - "7681:7681"     # ttyd terminal
-      
+
+      - "8080:8080"     # Audio Bridge / WebRTC
       - "4713:4713"     # PulseAudio
+      - "3478:3478"     # STUN/TURN
+      - "5901:5901"     # VNC
     env_file:
       - .env
     volumes:

--- a/ubuntu-kde-docker/docker-compose.prod.yml
+++ b/ubuntu-kde-docker/docker-compose.prod.yml
@@ -9,6 +9,9 @@ services:
       - "80:80"       # noVNC (behind reverse proxy)
       - "443:443"     # HTTPS (behind reverse proxy)
       - "2222:22"     # SSH
+      - "8080:8080"   # Audio Bridge / WebRTC
+      - "3478:3478"   # STUN/TURN
+      - "5901:5901"   # VNC
     env_file:
       - .env.production
     volumes:

--- a/ubuntu-kde-docker/docker-compose.yml
+++ b/ubuntu-kde-docker/docker-compose.yml
@@ -13,8 +13,10 @@ services:
       - "32768:80"      # noVNC
       - "2222:22"       # SSH
       - "7681:7681"     # ttyd terminal
-      - "8080:8080"     # Audio Bridge
+      - "8080:8080"     # Audio Bridge / WebRTC
       - "4713:4713"     # PulseAudio
+      - "3478:3478"     # STUN/TURN
+      - "5901:5901"     # VNC
     env_file:
       - .env
     volumes:


### PR DESCRIPTION
## Summary
- expose 3478 and 5901 for STUN/TURN and VNC access
- add 8080 Audio Bridge/WebRTC port
- propagate new ports to dev and prod compose files

## Testing
- `npm test` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_b_689509f718ec832f9f1d469451c82281