### PR TITLE
Run audio bridge server.js with WebRTC fallback

### DIFF
--- a/ubuntu-kde-docker/supervisord.conf
+++ b/ubuntu-kde-docker/supervisord.conf
@@ -194,7 +194,7 @@ depends_on=noVNC
 exitcodes=0
 
 [program:AudioBridge]
-command=/usr/bin/node /opt/audio-bridge/webrtc-audio-server.cjs
+command=/usr/bin/node /opt/audio-bridge/server.js
 priority=25
 autostart=true
 autorestart=true


### PR DESCRIPTION
## Summary
- Start audio bridge with `/opt/audio-bridge/server.js` under supervisor
- Generate audio bridge `server.js` with graceful `wrtc` fallback
- Package audio bridge with `ws` and `express` dependencies

## Testing
- `npm test`
- `node /opt/audio-bridge/server.js` (with and without wrtc)
- `supervisord -c /tmp/supervisord-audio.conf` (with and without wrtc)
- `docker build -f ubuntu-kde-docker/Dockerfile .` *(fails: Cannot connect to the Docker daemon at unix:///var/run/docker.sock)*


------
https://chatgpt.com/codex/tasks/task_b_689511585944832f937ec14ca6c7cd77