### PR TITLE
Ensure AudioBridge waits for PulseAudio

### DIFF
--- a/ubuntu-kde-docker/supervisord.conf
+++ b/ubuntu-kde-docker/supervisord.conf
@@ -200,7 +200,8 @@ autostart=true
 autorestart=true
 stopsignal=TERM
 user=root
-startsecs=3
+startsecs=20
+depends_on=pulseaudio
 stdout_logfile=/var/log/supervisor/audio-bridge.log
 stderr_logfile=/var/log/supervisor/audio-bridge.log
 


### PR DESCRIPTION
## Summary
- Start AudioBridge only after PulseAudio is running
- Allow extra startup time for PulseAudio

## Testing
- `supervisorctl -c /tmp/test-supervisord.conf status`
- `supervisorctl -c /tmp/test-supervisord.conf reread`
- `supervisorctl -c /tmp/test-supervisord.conf update`
- `tail -n 10 /tmp/test-supervisord.log`


------
https://chatgpt.com/codex/tasks/task_b_689516d39414832faec9a21cae246271