### PR TITLE
Run audio diagnostics as dev user

### DIFF
--- a/ubuntu-kde-docker/Dockerfile
+++ b/ubuntu-kde-docker/Dockerfile
@@ -256,8 +256,8 @@ RUN chmod +x /entrypoint.sh /tmp/xstartup
 # Ensure diagnostic script remains present and executable
 RUN test -x /usr/local/bin/diagnostic-and-fix.sh
 
-# Run diagnostic-and-fix.sh before entrypoint.sh
-ENTRYPOINT ["/bin/bash", "-c", "/usr/local/bin/diagnostic-and-fix.sh && exec /entrypoint.sh"]
+# Execute entrypoint script; diagnostic steps run as the dev user within entrypoint
+ENTRYPOINT ["/entrypoint.sh"]
 
 EXPOSE 22 80 8080 3478 5901 7681
 

--- a/ubuntu-kde-docker/diagnostic-and-fix.sh
+++ b/ubuntu-kde-docker/diagnostic-and-fix.sh
@@ -2,6 +2,9 @@
 # diagnostic-and-fix.sh: Automatic audio diagnostic and fix script for WebTop container
 set -euo pipefail
 
+# Assume the user's PulseAudio runtime directory is available
+export XDG_RUNTIME_DIR="${XDG_RUNTIME_DIR:-/run/user/$(id -u)}"
+
 LOG_FILE="${LOG_FILE:-/tmp/audio_diagnostic.log}"
 : >"$LOG_FILE"
 

--- a/ubuntu-kde-docker/entrypoint.sh
+++ b/ubuntu-kde-docker/entrypoint.sh
@@ -243,6 +243,12 @@ else
     echo "⚠️  Audio setup script not found"
 fi
 
+# Run post-setup diagnostics as the development user
+if [ -x /usr/local/bin/diagnostic-and-fix.sh ]; then
+    echo "🩺 Running audio diagnostic and fix as ${DEV_USERNAME}..."
+    su - "${DEV_USERNAME}" -c "/usr/local/bin/diagnostic-and-fix.sh" || log_warn "diagnostic-and-fix.sh failed"
+fi
+
 # Set up TTYD terminal service
 log_info "Setting up TTYD terminal service..."
 if [ -f "/usr/local/bin/setup-ttyd.sh" ]; then


### PR DESCRIPTION
## Summary
- Call diagnostic-and-fix.sh from entrypoint as the dev user
- Assume user's PulseAudio runtime dir in diagnostic script

## Testing
- `npm test`
- `docker build -t ubuntu-kde-test ubuntu-kde-docker` *(fails: Cannot connect to the Docker daemon)*


------
https://chatgpt.com/codex/tasks/task_b_689518b977a4832f9be5105a37753b2d