### PR TITLE
docs: add Android kernel module guidance

### DIFF
--- a/ubuntu-kde-docker/README.md
+++ b/ubuntu-kde-docker/README.md
@@ -39,6 +39,24 @@ A comprehensive Docker environment featuring Ubuntu with KDE Plasma desktop, spe
 - Docker & Docker Compose
 - 4GB+ RAM recommended
 - Modern web browser
+- (For Android support) binder_linux and ashmem_linux kernel modules on the host
+
+### Android Host Kernel Modules
+To run Android apps with Waydroid, the Docker host must load two kernel modules:
+
+```bash
+sudo apt install -y linux-modules-extra-$(uname -r)
+sudo modprobe binder_linux
+sudo modprobe ashmem_linux
+```
+
+You can verify the modules are present using:
+
+```bash
+lsmod | grep -e binder_linux -e ashmem_linux
+```
+
+Run `./check-android-modules.sh` before starting the container to confirm readiness.
 
 ### 1. Clone & Configure
 ```bash

--- a/ubuntu-kde-docker/check-android-modules.sh
+++ b/ubuntu-kde-docker/check-android-modules.sh
@@ -1,0 +1,19 @@
+#!/bin/bash
+# Pre-check for Android kernel modules needed by Waydroid
+set -e
+
+missing=()
+for mod in binder_linux ashmem_linux; do
+    if ! lsmod | grep -q "$mod"; then
+        missing+=("$mod")
+    fi
+done
+
+if [ ${#missing[@]} -ne 0 ]; then
+    echo "Missing kernel modules: ${missing[*]}" >&2
+    echo "Android support requires binder_linux and ashmem_linux on the host." >&2
+    echo "Refer to ubuntu-kde-docker/README.md#android-host-kernel-modules for loading instructions." >&2
+    exit 1
+else
+    echo "All required Android kernel modules are present."
+fi

--- a/ubuntu-kde-docker/setup-waydroid.sh
+++ b/ubuntu-kde-docker/setup-waydroid.sh
@@ -82,6 +82,7 @@ if ! lsmod | grep -q "binder_linux" || ! lsmod | grep -q "ashmem_linux"; then
     log_warn "Android subsystem setup failed: Missing required kernel modules."
     log_warn "The host system is missing 'binder_linux' and/or 'ashmem_linux' kernel modules."
     log_warn "These modules must be loaded on the Docker host to enable Android support."
+    log_warn "See ubuntu-kde-docker/README.md#android-host-kernel-modules for instructions."
     log_warn "Waydroid installation will be skipped."
 
     # Create a placeholder explaining the issue


### PR DESCRIPTION
## Summary
- document host setup for binder_linux and ashmem_linux modules
- warn about missing modules during Waydroid setup and add check script

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_b_68951ba68804832fb98d3e891a13b825