### PR TITLE
feat: refine audio bridge dependency install

### DIFF
--- a/ubuntu-kde-docker/setup-audio-bridge.sh
+++ b/ubuntu-kde-docker/setup-audio-bridge.sh
@@ -20,7 +20,9 @@ cat > package.json << 'EOF'
   "main": "webrtc-audio-server.cjs",
   "dependencies": {
     "express": "^4.18.2",
-    "ws": "^8.14.2",
+    "ws": "^8.14.2"
+  },
+  "optionalDependencies": {
     "wrtc": "^0.4.7"
   },
   "scripts": {
@@ -29,16 +31,16 @@ cat > package.json << 'EOF'
 }
 EOF
 
-# Install dependencies with fallback for wrtc
+# Install declared dependencies
 echo "Installing Node.js dependencies..."
-npm install express ws --production || {
+npm install --omit=dev || {
     echo "Failed to install basic dependencies, trying alternative approach..."
-    npm install --no-optional express ws
+    npm install --omit=dev --no-optional
 }
 
 # Try to install wrtc, but don't fail if it doesn't work
 echo "Attempting to install WebRTC support..."
-npm install wrtc --production || {
+npm install wrtc --omit=dev || {
     echo "Warning: wrtc module failed to install, WebRTC will be disabled"
     echo "WebSocket fallback will still work"
 }


### PR DESCRIPTION
## Summary
- generate audio bridge package.json with only express and ws as dependencies and wrtc optional
- install dependencies via `npm install --omit=dev` and attempt wrtc separately

## Testing
- `npm test` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_b_6895f7968ab8832f85c63ca5bee3caf0