### PR TITLE
Handle WebRTC tracks without associated streams

### DIFF
--- a/ubuntu-kde-docker/shared-audio-client.js
+++ b/ubuntu-kde-docker/shared-audio-client.js
@@ -137,9 +137,9 @@ class SharedAudioClient {
                 streams: event.streams.length,
                 tracks: event.streams[0]?.getTracks().length
             });
-            
+
             try {
-                const stream = event.streams[0];
+                const stream = event.streams[0] || new MediaStream([event.track]);
                 const source = this.audioContext.createMediaStreamSource(stream);
                 source.connect(this.gainNode);
                 this.log('WebRTC audio source connected to gain node');


### PR DESCRIPTION
## Summary
- Allow WebRTC audio client to create a MediaStream when incoming tracks have no associated stream

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_b_689610029ef0832f9941c34c95864c33