### PR TITLE
feat: allow disabling websocket fallback

### DIFF
--- a/ubuntu-kde-docker/Dockerfile
+++ b/ubuntu-kde-docker/Dockerfile
@@ -154,6 +154,7 @@ ENV WEBRTC_TURN_SERVER=""
 ENV WEBRTC_TURN_USERNAME=""
 ENV WEBRTC_TURN_PASSWORD=""
 ENV WEBRTC_PORT=8080
+ENV ENABLE_WEBSOCKET_FALLBACK=true
 # Create directories and VNC setup for x11vnc
 RUN mkdir -p /var/run/sshd /root/.vnc /tmp/.X11-unix && \
     chmod 1777 /tmp/.X11-unix

--- a/ubuntu-kde-docker/docs/WEBRTC_CONFIGURATION.md
+++ b/ubuntu-kde-docker/docs/WEBRTC_CONFIGURATION.md
@@ -336,3 +336,13 @@ const getRegionalTurnServer = () => {
 ```
 
 This configuration ensures optimal WebRTC performance while maintaining reliable WebSocket fallback for all network conditions.
+
+### Enforce WebRTC-only Connections
+
+To disable the automatic WebSocket fallback and require WebRTC, set the following in `audio-env.js` or as an environment variable:
+
+```javascript
+window.ENABLE_WEBSOCKET_FALLBACK = false;
+```
+
+When this flag is `false`, clients will not attempt a WebSocket connection if WebRTC fails.

--- a/ubuntu-kde-docker/entrypoint.sh
+++ b/ubuntu-kde-docker/entrypoint.sh
@@ -63,12 +63,14 @@ console.log('Loading audio environment configuration...');
 window.AUDIO_HOST = '${AUDIO_HOST}';
 window.AUDIO_PORT = ${AUDIO_PORT};
 window.AUDIO_WS_SCHEME = '${AUDIO_WS_SCHEME}';
+window.ENABLE_WEBSOCKET_FALLBACK = ${ENABLE_WEBSOCKET_FALLBACK:-true};
 
 // Debug information
 console.log('Audio configuration:', {
     host: window.AUDIO_HOST,
     port: window.AUDIO_PORT,
-    scheme: window.AUDIO_WS_SCHEME
+    scheme: window.AUDIO_WS_SCHEME,
+    enableWebSocketFallback: window.ENABLE_WEBSOCKET_FALLBACK
 });
 
 // Validate configuration

--- a/ubuntu-kde-docker/integrate-audio-ui.sh
+++ b/ubuntu-kde-docker/integrate-audio-ui.sh
@@ -410,6 +410,7 @@ window.WEBRTC_STUN_SERVER = window.WEBRTC_STUN_SERVER || '';
 window.WEBRTC_TURN_SERVER = window.WEBRTC_TURN_SERVER || '';
 window.WEBRTC_TURN_USERNAME = window.WEBRTC_TURN_USERNAME || '';
 window.WEBRTC_TURN_PASSWORD = window.WEBRTC_TURN_PASSWORD || '';
+window.ENABLE_WEBSOCKET_FALLBACK = window.ENABLE_WEBSOCKET_FALLBACK !== undefined ? window.ENABLE_WEBSOCKET_FALLBACK : true;
 EOF
 
 # Create standalone audio player for testing


### PR DESCRIPTION
## Summary
- add `enableWebSocketFallback` option to shared audio client with environment variable support
- expose `ENABLE_WEBSOCKET_FALLBACK` in Docker and audio env configs
- document how to enforce WebRTC-only audio connections

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_b_68962b7036f0832f853b8db292f7eb91