### PR TITLE
Warn when TURN server unset and document TURN requirements

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,6 +104,11 @@ setting the following environment variables when launching the container:
 - `WEBRTC_TURN_USERNAME` – TURN authentication username
 - `WEBRTC_TURN_PASSWORD` – TURN authentication password
 
+For reliable connectivity behind NAT or firewalls, a TURN server must be
+available and its UDP port 3478 exposed. See
+[docs/WEBRTC_CONFIGURATION.md](docs/WEBRTC_CONFIGURATION.md) for a sample
+`docker-compose` setup with port mappings.
+
 If negotiation fails, the client automatically falls back to the legacy
 WebSocket audio stream.
 

--- a/docs/WEBRTC_CONFIGURATION.md
+++ b/docs/WEBRTC_CONFIGURATION.md
@@ -1,0 +1,31 @@
+# WebRTC Configuration
+
+Reliable WebRTC audio requires a reachable TURN server. STUN alone cannot traverse strict NAT or firewall rules. If `WEBRTC_TURN_SERVER` is not configured, connections may fail.
+
+The TURN server typically listens on UDP port **3478**. Ensure this port (and any additional ports your TURN server uses) is exposed so clients can reach it.
+
+## docker-compose example
+
+```yaml
+version: "3"
+services:
+  turn:
+    image: coturn/coturn
+    ports:
+      - "3478:3478/udp"
+      - "3478:3478/tcp"
+    command: ["--no-cli", "--log-file=stdout"]
+  webtop:
+    image: your-webtop-image
+    environment:
+      WEBRTC_STUN_SERVER: stun:stun.l.google.com:19302
+      WEBRTC_TURN_SERVER: turn:turn:3478
+      WEBRTC_TURN_USERNAME: user
+      WEBRTC_TURN_PASSWORD: pass
+    depends_on:
+      - turn
+    ports:
+      - "8080:8080"
+```
+
+Expose additional UDP ranges if your TURN server requires them for relayed traffic.

--- a/ubuntu-kde-docker/shared-audio-client.js
+++ b/ubuntu-kde-docker/shared-audio-client.js
@@ -23,6 +23,8 @@ class SharedAudioClient {
         this.retryCount = 0;
         this.maxRetries = 3;
         this.statusHandlers = [];
+
+        this.turnWarningLogged = false;
         
         this.debugMode = options.debug || false;
         
@@ -67,13 +69,16 @@ class SharedAudioClient {
         if (window.WEBRTC_STUN_SERVER) {
             servers.push({ urls: window.WEBRTC_STUN_SERVER });
         }
-        
+
         if (window.WEBRTC_TURN_SERVER) {
             servers.push({
                 urls: window.WEBRTC_TURN_SERVER,
                 username: window.WEBRTC_TURN_USERNAME || undefined,
                 credential: window.WEBRTC_TURN_PASSWORD || undefined
             });
+        } else if (!this.turnWarningLogged) {
+            console.warn('WEBRTC_TURN_SERVER is not set; WebRTC may fail behind restrictive networks');
+            this.turnWarningLogged = true;
         }
         
         this.log('ICE servers configured', servers);

--- a/ubuntu-kde-docker/webrtc-audio-server.cjs
+++ b/ubuntu-kde-docker/webrtc-audio-server.cjs
@@ -21,6 +21,10 @@ try {
 const PORT = process.env.WEBRTC_PORT || process.env.AUDIO_PORT || 8080;
 const app = express();
 
+if (!process.env.WEBRTC_TURN_SERVER) {
+  console.warn('WEBRTC_TURN_SERVER is not set; WebRTC may fail behind restrictive networks');
+}
+
 // Enable CORS for all routes
 app.use((req, res, next) => {
   res.header('Access-Control-Allow-Origin', '*');


### PR DESCRIPTION
## Summary
- warn in WebRTC audio server and client when `WEBRTC_TURN_SERVER` is missing
- document TURN server and UDP 3478 requirement with docker-compose example

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_68962df2561c832f894db6eadb523460