### PR TITLE
Add WebRTC proxy config for audio bridge

### DIFF
--- a/ubuntu-kde-docker/nginx-audio-proxy.conf
+++ b/ubuntu-kde-docker/nginx-audio-proxy.conf
@@ -40,6 +40,24 @@ location /audio-stream {
     proxy_cache off;
 }
 
+# Proxy WebRTC WebSocket connections
+location /webrtc {
+    proxy_pass http://audio-bridge:PORT/webrtc;
+    proxy_http_version 1.1;
+    proxy_set_header Upgrade $http_upgrade;
+    proxy_set_header Connection "upgrade";
+    proxy_set_header Host $host;
+    proxy_set_header X-Real-IP $remote_addr;
+    proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+    proxy_set_header X-Forwarded-Proto $scheme;
+    proxy_read_timeout 86400;
+    proxy_send_timeout 86400;
+
+    # WebSocket specific settings
+    proxy_buffering off;
+    proxy_cache off;
+}
+
 # Health check endpoint
 location /health {
     proxy_pass http://localhost:8080/health;


### PR DESCRIPTION
## Summary
- proxy /webrtc WebSocket connections through nginx to audio-bridge host

## Testing
- `node -e "const http=require('http'),crypto=require('crypto');const key=crypto.randomBytes(16).toString('base64');const options={hostname:'localhost',port:8080,path:'/webrtc',headers:{'Connection':'Upgrade','Upgrade':'websocket','Sec-WebSocket-Key':key,'Sec-WebSocket-Version':'13'}};const req=http.request(options);req.on('upgrade',(res,socket)=>{console.log('status',res.statusCode);socket.end();process.exit(0);});req.on('response',res=>{console.log('response',res.statusCode);process.exit(1);});req.end();"`

------
https://chatgpt.com/codex/tasks/task_b_689639906f48832f81506f54b7b772dd