### PR TITLE
Include universal audio script in Docker build

### DIFF
--- a/ubuntu-kde-docker/Dockerfile
+++ b/ubuntu-kde-docker/Dockerfile
@@ -202,6 +202,7 @@ RUN /usr/local/bin/setup-ttyd.sh
 # Setup audio bridge
 COPY setup-audio-bridge.sh webrtc-audio-server.cjs test-webrtc-websocket-audio.sh /usr/local/bin/
 COPY shared-audio-client.js /usr/local/bin/
+COPY universal-audio.js /opt/audio-bridge/
 COPY integrate-audio-ui.sh /usr/local/bin/
 RUN chmod +x /usr/local/bin/setup-audio-bridge.sh && \
     chmod +x /usr/local/bin/integrate-audio-ui.sh && \

--- a/ubuntu-kde-docker/setup-universal-audio.sh
+++ b/ubuntu-kde-docker/setup-universal-audio.sh
@@ -28,14 +28,14 @@ check_novnc_ready() {
 # Copy universal audio script
 if [ -f "$UNIVERSAL_AUDIO_SCRIPT" ] && check_novnc_ready; then
     echo "🔧 Copying universal audio script..."
-    cp "$UNIVERSAL_AUDIO_SCRIPT" "$NOVNC_DIR/" 2>/dev/null || {
+    cp "$UNIVERSAL_AUDIO_SCRIPT" "$NOVNC_DIR/universal-audio.js" 2>/dev/null || {
         echo "⚠️  Could not copy audio script, continuing..."
     }
-    
+
     # Set permissions
     chmod 644 "$NOVNC_DIR"/*.js 2>/dev/null || true
     chmod 644 "$NOVNC_DIR"/*.html 2>/dev/null || true
-    
+
     echo "✅ Universal audio integration setup completed"
 else
     echo "⚠️  Universal audio script not found or noVNC not ready, skipping"


### PR DESCRIPTION
## Summary
- ensure `universal-audio.js` is included in `/opt/audio-bridge` during image build
- copy `universal-audio.js` to `/usr/share/novnc` so the script is served with noVNC pages

## Testing
- `npm test`
- `docker build -t webtop-audio-test -f ubuntu-kde-docker/Dockerfile .` *(fails: Cannot connect to the Docker daemon; failed to start daemon due to permission issues)*

------
https://chatgpt.com/codex/tasks/task_b_68963ab56f48832f99a2b79a74a8f6c1