### PR TITLE
Bundle internal STUN/TURN server for WebRTC audio

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,8 +96,7 @@
 
 ### WebRTC Audio Configuration
 
-The audio bridge now supports WebRTC streaming. Configure STUN/TURN servers by
-setting the following environment variables when launching the container:
+The audio bridge now supports WebRTC streaming. A bundled [coturn](https://github.com/coturn/coturn) server runs inside the container and is exposed on port **3478** using default credentials `webtop:webtop`. Configure STUN/TURN servers by setting the following environment variables when launching the container (override them if you deploy an external TURN service):
 
 - `WEBRTC_STUN_SERVER` – STUN server URL (e.g. `stun:stun.l.google.com:19302`)
 - `WEBRTC_TURN_SERVER` – TURN server URL

--- a/docs/WEBRTC_CONFIGURATION.md
+++ b/docs/WEBRTC_CONFIGURATION.md
@@ -2,7 +2,9 @@
 
 Reliable WebRTC audio requires a reachable TURN server. STUN alone cannot traverse strict NAT or firewall rules. If `WEBRTC_TURN_SERVER` is not configured, connections may fail.
 
-The TURN server typically listens on UDP port **3478**. Ensure this port (and any additional ports your TURN server uses) is exposed so clients can reach it.
+This project now ships with a lightweight [coturn](https://github.com/coturn/coturn) server that starts automatically inside the container.  By default it listens on port **3478** with credentials `webtop:webtop` and is exposed to clients as both STUN and TURN under `stun:localhost:3478` / `turn:localhost:3478`.
+
+The TURN server typically listens on UDP port **3478**. Ensure this port (and any additional ports your TURN server uses) is exposed so clients can reach it or override the environment variables to point to an external service.
 
 ## docker-compose example
 

--- a/ubuntu-kde-docker/Dockerfile
+++ b/ubuntu-kde-docker/Dockerfile
@@ -48,7 +48,7 @@ RUN apt-get update && apt-get install -y \
     # File managers and utilities
     mc ranger fzf ripgrep fd-find \
     # Network and security tools
-    nmap wireshark \
+    nmap wireshark coturn \
     # Virtualization
     qemu-system-x86 virt-manager \
     nextcloud-desktop \
@@ -149,10 +149,10 @@ ENV LANGUAGE=en_US.UTF-8
 ENV LC_ALL=en_US.UTF-8
 ENV TTYD_USER=terminal
 ENV TTYD_PASSWORD=terminal
-ENV WEBRTC_STUN_SERVER=""
-ENV WEBRTC_TURN_SERVER=""
-ENV WEBRTC_TURN_USERNAME=""
-ENV WEBRTC_TURN_PASSWORD=""
+ENV WEBRTC_STUN_SERVER="stun:localhost:3478"
+ENV WEBRTC_TURN_SERVER="turn:localhost:3478"
+ENV WEBRTC_TURN_USERNAME="webtop"
+ENV WEBRTC_TURN_PASSWORD="webtop"
 ENV WEBRTC_PORT=8080
 ENV ENABLE_WEBSOCKET_FALLBACK=true
 # Create directories and VNC setup for x11vnc
@@ -203,9 +203,10 @@ RUN /usr/local/bin/setup-ttyd.sh
 COPY setup-audio-bridge.sh webrtc-audio-server.cjs test-webrtc-websocket-audio.sh /usr/local/bin/
 COPY shared-audio-client.js /usr/local/bin/
 COPY universal-audio.js /opt/audio-bridge/
-COPY integrate-audio-ui.sh /usr/local/bin/
+COPY integrate-audio-ui.sh start-turn.sh /usr/local/bin/
 RUN chmod +x /usr/local/bin/setup-audio-bridge.sh && \
     chmod +x /usr/local/bin/integrate-audio-ui.sh && \
+    chmod +x /usr/local/bin/start-turn.sh && \
     chmod +x /usr/local/bin/test-webrtc-websocket-audio.sh && \
     /usr/local/bin/setup-audio-bridge.sh && \
     /usr/local/bin/integrate-audio-ui.sh

--- a/ubuntu-kde-docker/start-turn.sh
+++ b/ubuntu-kde-docker/start-turn.sh
@@ -1,0 +1,12 @@
+#!/bin/bash
+set -e
+
+TURN_PORT="${WEBRTC_TURN_PORT:-3478}"
+REALM="${WEBRTC_TURN_REALM:-webtop}"
+USER="${WEBRTC_TURN_USERNAME:-webtop}"
+PASS="${WEBRTC_TURN_PASSWORD:-webtop}"
+
+exec /usr/bin/turnserver -a -v --no-cli --no-tls --no-dtls \
+  --listening-port "$TURN_PORT" \
+  --realm "$REALM" \
+  --user "$USER:$PASS"

--- a/ubuntu-kde-docker/supervisord.conf
+++ b/ubuntu-kde-docker/supervisord.conf
@@ -148,6 +148,16 @@ autorestart_backoff=60
 stdout_logfile=/var/log/supervisor/audio-monitor.log
 stderr_logfile=/var/log/supervisor/audio-monitor.log
 
+[program:TurnServer]
+command=/usr/local/bin/start-turn.sh
+priority=24
+autostart=true
+autorestart=true
+stopsignal=TERM
+user=root
+stdout_logfile=/var/log/supervisor/turnserver.log
+stderr_logfile=/var/log/supervisor/turnserver.log
+
 [program:ServiceHealth]
 command=/bin/sh -c "sleep 75; /usr/local/bin/service-health.sh smart-monitor"
 priority=55
@@ -224,7 +234,7 @@ programs=Xvfb,dbus,accounts-daemon
 priority=10
 
 [group:audio]
-programs=pulseaudio,AudioValidation,CreateVirtualAudioDevices,AudioMonitor,AudioBridge
+programs=pulseaudio,AudioValidation,CreateVirtualAudioDevices,AudioMonitor,TurnServer,AudioBridge
 priority=25
 
 [group:desktop]


### PR DESCRIPTION
## Summary
- install `coturn` and provide default STUN/TURN environment values
- add startup script and supervisor entry to run bundled TURN server
- document built-in STUN/TURN support

## Testing
- `npm test`
- `bash ubuntu-kde-docker/test-webrtc-websocket-audio.sh` *(fails: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_b_68963512f2f4832f9202d32c146d8d2c