### PR TITLE
fix: expose TURN config and handle localhost

### DIFF
--- a/docs/WEBRTC_CONFIGURATION.md
+++ b/docs/WEBRTC_CONFIGURATION.md
@@ -4,6 +4,8 @@ Reliable WebRTC audio requires a reachable TURN server. STUN alone cannot traver
 
 This project now ships with a lightweight [coturn](https://github.com/coturn/coturn) server that starts automatically inside the container.  By default it listens on port **3478** with credentials `webtop:webtop` and is exposed to clients as both STUN and TURN under `stun:localhost:3478` / `turn:localhost:3478`.
 
+When these default `localhost` URLs are used, the client automatically rewrites them to use the page's current hostname. This allows browsers connecting to containerized environments to reach the TURN server without manual configuration.
+
 The TURN server typically listens on UDP port **3478**. Ensure this port (and any additional ports your TURN server uses) is exposed so clients can reach it or override the environment variables to point to an external service.
 
 ## docker-compose example

--- a/ubuntu-kde-docker/docs/WEBRTC_CONFIGURATION.md
+++ b/ubuntu-kde-docker/docs/WEBRTC_CONFIGURATION.md
@@ -4,6 +4,8 @@
 
 The Ubuntu KDE WebTop now supports WebRTC-first audio streaming with automatic WebSocket fallback. This guide covers configuration options for optimal WebRTC performance, especially over the internet.
 
+If `WEBRTC_TURN_SERVER` is set to a `localhost` address (for example `turn:localhost:3478`), the client will automatically replace `localhost` with the current page's hostname. This ensures the embedded TURN server remains reachable when the container is accessed remotely.
+
 ## Environment Variables
 
 Add these to your `.env` file for WebRTC configuration:

--- a/ubuntu-kde-docker/entrypoint.sh
+++ b/ubuntu-kde-docker/entrypoint.sh
@@ -41,11 +41,21 @@ if [ -f "$ENV_FILE" ]; then
     sed -i "s/^AUDIO_HOST=.*/AUDIO_HOST=${AUDIO_HOST}/" "$ENV_FILE"
     sed -i "s/^AUDIO_PORT=.*/AUDIO_PORT=${AUDIO_PORT}/" "$ENV_FILE"
     sed -i "s/^AUDIO_WS_SCHEME=.*/AUDIO_WS_SCHEME=${AUDIO_WS_SCHEME}/" "$ENV_FILE"
+    sed -i "s/^WEBRTC_PORT=.*/WEBRTC_PORT=${WEBRTC_PORT:-$AUDIO_PORT}/" "$ENV_FILE"
+    sed -i "s/^WEBRTC_STUN_SERVER=.*/WEBRTC_STUN_SERVER=${WEBRTC_STUN_SERVER}/" "$ENV_FILE"
+    sed -i "s/^WEBRTC_TURN_SERVER=.*/WEBRTC_TURN_SERVER=${WEBRTC_TURN_SERVER}/" "$ENV_FILE"
+    sed -i "s/^WEBRTC_TURN_USERNAME=.*/WEBRTC_TURN_USERNAME=${WEBRTC_TURN_USERNAME}/" "$ENV_FILE"
+    sed -i "s/^WEBRTC_TURN_PASSWORD=.*/WEBRTC_TURN_PASSWORD=${WEBRTC_TURN_PASSWORD}/" "$ENV_FILE"
 elif [ -f "/.env" ]; then
     ENV_FILE="/.env"
     sed -i "s/^AUDIO_HOST=.*/AUDIO_HOST=${AUDIO_HOST}/" "$ENV_FILE"
     sed -i "s/^AUDIO_PORT=.*/AUDIO_PORT=${AUDIO_PORT}/" "$ENV_FILE"
     sed -i "s/^AUDIO_WS_SCHEME=.*/AUDIO_WS_SCHEME=${AUDIO_WS_SCHEME}/" "$ENV_FILE"
+    sed -i "s/^WEBRTC_PORT=.*/WEBRTC_PORT=${WEBRTC_PORT:-$AUDIO_PORT}/" "$ENV_FILE"
+    sed -i "s/^WEBRTC_STUN_SERVER=.*/WEBRTC_STUN_SERVER=${WEBRTC_STUN_SERVER}/" "$ENV_FILE"
+    sed -i "s/^WEBRTC_TURN_SERVER=.*/WEBRTC_TURN_SERVER=${WEBRTC_TURN_SERVER}/" "$ENV_FILE"
+    sed -i "s/^WEBRTC_TURN_USERNAME=.*/WEBRTC_TURN_USERNAME=${WEBRTC_TURN_USERNAME}/" "$ENV_FILE"
+    sed -i "s/^WEBRTC_TURN_PASSWORD=.*/WEBRTC_TURN_PASSWORD=${WEBRTC_TURN_PASSWORD}/" "$ENV_FILE"
 fi
 
 # Write audio configuration for browser clients with validation
@@ -65,12 +75,22 @@ window.AUDIO_PORT = ${AUDIO_PORT};
 window.AUDIO_WS_SCHEME = '${AUDIO_WS_SCHEME}';
 window.ENABLE_WEBSOCKET_FALLBACK = ${ENABLE_WEBSOCKET_FALLBACK:-true};
 
+// WebRTC configuration
+window.WEBRTC_PORT = ${WEBRTC_PORT:-${AUDIO_PORT}};
+window.WEBRTC_STUN_SERVER = '${WEBRTC_STUN_SERVER}';
+window.WEBRTC_TURN_SERVER = '${WEBRTC_TURN_SERVER}';
+window.WEBRTC_TURN_USERNAME = '${WEBRTC_TURN_USERNAME}';
+window.WEBRTC_TURN_PASSWORD = '${WEBRTC_TURN_PASSWORD}';
+
 // Debug information
 console.log('Audio configuration:', {
     host: window.AUDIO_HOST,
     port: window.AUDIO_PORT,
     scheme: window.AUDIO_WS_SCHEME,
-    enableWebSocketFallback: window.ENABLE_WEBSOCKET_FALLBACK
+    enableWebSocketFallback: window.ENABLE_WEBSOCKET_FALLBACK,
+    webrtcPort: window.WEBRTC_PORT,
+    stunServer: window.WEBRTC_STUN_SERVER,
+    turnServer: window.WEBRTC_TURN_SERVER
 });
 
 // Validate configuration

--- a/ubuntu-kde-docker/shared-audio-client.js
+++ b/ubuntu-kde-docker/shared-audio-client.js
@@ -71,8 +71,13 @@ class SharedAudioClient {
         }
 
         if (window.WEBRTC_TURN_SERVER) {
+            let turnUrl = window.WEBRTC_TURN_SERVER;
+            const host = window.location.hostname;
+            if (turnUrl.includes('localhost') || turnUrl.includes('127.0.0.1')) {
+                turnUrl = turnUrl.replace('localhost', host).replace('127.0.0.1', host);
+            }
             servers.push({
-                urls: window.WEBRTC_TURN_SERVER,
+                urls: turnUrl,
                 username: window.WEBRTC_TURN_USERNAME || undefined,
                 credential: window.WEBRTC_TURN_PASSWORD || undefined
             });

--- a/ubuntu-kde-docker/universal-audio.js
+++ b/ubuntu-kde-docker/universal-audio.js
@@ -412,8 +412,13 @@
                 servers.push({ urls: window.WEBRTC_STUN_SERVER });
             }
             if (window.WEBRTC_TURN_SERVER) {
+                let turnUrl = window.WEBRTC_TURN_SERVER;
+                const host = window.location.hostname;
+                if (turnUrl.includes('localhost') || turnUrl.includes('127.0.0.1')) {
+                    turnUrl = turnUrl.replace('localhost', host).replace('127.0.0.1', host);
+                }
                 servers.push({
-                    urls: window.WEBRTC_TURN_SERVER,
+                    urls: turnUrl,
                     username: window.WEBRTC_TURN_USERNAME || undefined,
                     credential: window.WEBRTC_TURN_PASSWORD || undefined
                 });


### PR DESCRIPTION
## Summary
- surface WebRTC STUN/TURN configuration to browser clients via `audio-env.js`
- normalize TURN URLs that point to localhost for container access
- document automatic TURN host rewriting for container deployments

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_689654d0add4832fa023aa83ca65fded