### PR TITLE
Add WebRTC proxy endpoint to Nginx config

### DIFF
--- a/ubuntu-kde-docker/nginx.conf
+++ b/ubuntu-kde-docker/nginx.conf
@@ -130,6 +130,21 @@ http {
             proxy_cache off;
         }
 
+        location /webrtc {
+            proxy_pass http://webtop:8080/webrtc;
+            proxy_http_version 1.1;
+            proxy_set_header Upgrade $http_upgrade;
+            proxy_set_header Connection "upgrade";
+            proxy_set_header Host $host;
+            proxy_set_header X-Real-IP $remote_addr;
+            proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+            proxy_set_header X-Forwarded-Proto $scheme;
+            proxy_read_timeout 86400;
+            proxy_send_timeout 86400;
+            proxy_buffering off;
+            proxy_cache off;
+        }
+
         # Health check endpoint
         location /health {
             proxy_pass http://webtop:8080/health;


### PR DESCRIPTION
## Summary
- proxy /webrtc to webtop:8080/webrtc with WebSocket headers in nginx.conf

## Testing
- `npm test`
- `nginx -s reload` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_b_68966454cba8832f8776789edbc1433a