### PR TITLE
Use 48k stereo audio for WebRTC and WebSocket

### DIFF
--- a/ubuntu-kde-docker/shared-audio-client.js
+++ b/ubuntu-kde-docker/shared-audio-client.js
@@ -353,7 +353,7 @@ class SharedAudioClient {
             }
             
             const frameLength = samples.length / 2;
-            const audioBuffer = this.audioContext.createBuffer(2, frameLength, 44100);
+            const audioBuffer = this.audioContext.createBuffer(2, frameLength, 48000);
             
             const leftChannel = audioBuffer.getChannelData(0);
             const rightChannel = audioBuffer.getChannelData(1);
@@ -374,7 +374,7 @@ class SharedAudioClient {
             // Schedule playback with small buffer to prevent gaps
             const playTime = Math.max(this.audioContext.currentTime, this.lastPlayTime || 0);
             source.start(playTime);
-            this.lastPlayTime = playTime + (frameLength / 44100);
+            this.lastPlayTime = playTime + (frameLength / 48000);
             
             // Clean up source after playback
             setTimeout(() => {
@@ -383,7 +383,7 @@ class SharedAudioClient {
                 } catch (e) {
                     // Source already disconnected
                 }
-            }, (frameLength / 44100) * 1000 + 100);
+            }, (frameLength / 48000) * 1000 + 100);
             
         } catch (error) {
             this.log('Audio processing error:', error.message);

--- a/ubuntu-kde-docker/webrtc-audio-server.cjs
+++ b/ubuntu-kde-docker/webrtc-audio-server.cjs
@@ -109,7 +109,7 @@ app.post('/offer', async (req, res) => {
       '--device=virtual_speaker.monitor',
       '--format=s16le',
       '--rate=48000',
-      '--channels=1',
+      '--channels=2',
       '--raw'
     ]);
 
@@ -120,7 +120,7 @@ app.post('/offer', async (req, res) => {
           source.onData({
             samples: data,
             sampleRate: 48000,
-            channelCount: 1,
+            channelCount: 2,
             bitsPerSample: 16
           });
         }
@@ -211,7 +211,7 @@ wss.on('connection', (ws, req) => {
   const recorder = spawn('parecord', [
     '--device=virtual_speaker.monitor',
     '--format=s16le',
-    '--rate=44100',
+    '--rate=48000',
     '--channels=2',
     '--raw'
   ]);


### PR DESCRIPTION
## Summary
- Standardize WebRTC and WebSocket audio capture to 48 kHz stereo
- Match client-side playback buffers and timing to 48 kHz

## Testing
- `npm test`
- `node --test ubuntu-kde-docker/test/audio-bridge.test.cjs`


------
https://chatgpt.com/codex/tasks/task_b_6896654e9038832f814c95c249642855