### PR TITLE
Infer audio ports from browser location

### DIFF
--- a/ubuntu-kde-docker/audio-env.js
+++ b/ubuntu-kde-docker/audio-env.js
@@ -1,0 +1,32 @@
+// Audio environment configuration
+// Generated for development
+console.log('Loading audio environment configuration...');
+
+window.AUDIO_HOST = '';
+window.AUDIO_PORT = window.location.port;
+window.AUDIO_WS_SCHEME = '';
+window.ENABLE_WEBSOCKET_FALLBACK = true;
+
+// WebRTC configuration
+window.WEBRTC_PORT = window.location.port;
+window.WEBRTC_STUN_SERVER = '';
+window.WEBRTC_TURN_SERVER = '';
+window.WEBRTC_TURN_USERNAME = '';
+window.WEBRTC_TURN_PASSWORD = '';
+
+// Debug information
+console.log('Audio configuration:', {
+    host: window.AUDIO_HOST,
+    port: window.AUDIO_PORT,
+    scheme: window.AUDIO_WS_SCHEME,
+    enableWebSocketFallback: window.ENABLE_WEBSOCKET_FALLBACK,
+    webrtcPort: window.WEBRTC_PORT,
+    stunServer: window.WEBRTC_STUN_SERVER,
+    turnServer: window.WEBRTC_TURN_SERVER
+});
+
+// Validate configuration
+if (!window.AUDIO_PORT || window.AUDIO_PORT < 1 || window.AUDIO_PORT > 65535) {
+    console.warn('Invalid audio port configuration:', window.AUDIO_PORT);
+}
+

--- a/ubuntu-kde-docker/shared-audio-client.js
+++ b/ubuntu-kde-docker/shared-audio-client.js
@@ -5,8 +5,12 @@
 class SharedAudioClient {
     constructor(options = {}) {
         this.audioHost = options.audioHost || window.AUDIO_HOST || window.location.hostname;
-        this.audioPort = options.audioPort || window.AUDIO_PORT || 8080;
-        this.webrtcPort = options.webrtcPort || window.WEBRTC_PORT || this.audioPort;
+        this.audioPort =
+            options.audioPort !== undefined ? options.audioPort :
+            (typeof window.AUDIO_PORT !== 'undefined' ? window.AUDIO_PORT : 8080);
+        this.webrtcPort =
+            options.webrtcPort !== undefined ? options.webrtcPort :
+            (typeof window.WEBRTC_PORT !== 'undefined' ? window.WEBRTC_PORT : this.audioPort);
         this.wsScheme = options.wsScheme || window.AUDIO_WS_SCHEME || (window.location.protocol === 'https:' ? 'wss' : 'ws');
 
         const fallbackConfig = options.enableWebSocketFallback ?? window.ENABLE_WEBSOCKET_FALLBACK;
@@ -151,8 +155,9 @@ class SharedAudioClient {
         this.peerConnection = pc;
 
         // Try multiple signaling URLs for ICE candidates
+        const signalPort = this.webrtcPort ? `:${this.webrtcPort}` : '';
         const signalUrls = [
-            `${this.wsScheme}://${this.audioHost}:${this.webrtcPort}/webrtc`,
+            `${this.wsScheme}://${this.audioHost}${signalPort}/webrtc`,
             `${this.wsScheme}://${window.location.host}/webrtc` // Same-origin fallback
         ];
 
@@ -242,8 +247,9 @@ class SharedAudioClient {
         this.log('WebRTC offer created');
         
         // Try multiple offer endpoints
+        const offerPort = this.webrtcPort ? `:${this.webrtcPort}` : '';
         const offerUrls = [
-            `http://${this.audioHost}:${this.webrtcPort}/offer`,
+            `http://${this.audioHost}${offerPort}/offer`,
             `/offer` // Same-origin fallback if proxied
         ];
         
@@ -297,8 +303,9 @@ class SharedAudioClient {
         this.log('Attempting WebSocket connection...');
         
         // Try multiple WebSocket URLs
+        const wsPort = this.audioPort ? `:${this.audioPort}` : '';
         const wsUrls = [
-            `${this.wsScheme}://${this.audioHost}:${this.audioPort}/audio-stream`,
+            `${this.wsScheme}://${this.audioHost}${wsPort}/audio-stream`,
             `${this.wsScheme}://${window.location.host}/audio-stream` // Same-origin fallback
         ];
         


### PR DESCRIPTION
## Summary
- Infer audio and WebRTC ports from the current browser location when environment values are missing
- Respect empty port values in `SharedAudioClient` and avoid appending unused port segments to URLs
- Regenerate `audio-env.js` with port defaults based on `window.location.port`

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_b_689711a7019c832fbd30d5669802632e