### PR TITLE
Add PulseAudio health checks for AudioBridge startup

### DIFF
--- a/ubuntu-kde-docker/Dockerfile
+++ b/ubuntu-kde-docker/Dockerfile
@@ -200,14 +200,16 @@ RUN /usr/local/bin/setup-audio.sh && \
 RUN /usr/local/bin/setup-ttyd.sh
 
 # Setup audio bridge
-COPY setup-audio-bridge.sh webrtc-audio-server.cjs test-webrtc-websocket-audio.sh /usr/local/bin/
+COPY setup-audio-bridge.sh start-pulseaudio.sh start-audio-bridge.sh webrtc-audio-server.cjs test-webrtc-websocket-audio.sh /usr/local/bin/
 COPY shared-audio-client.js /usr/local/bin/
 COPY universal-audio.js /opt/audio-bridge/
 COPY integrate-audio-ui.sh start-turn.sh /usr/local/bin/
-RUN chmod +x /usr/local/bin/setup-audio-bridge.sh && \
-    chmod +x /usr/local/bin/integrate-audio-ui.sh && \
-    chmod +x /usr/local/bin/start-turn.sh && \
-    chmod +x /usr/local/bin/test-webrtc-websocket-audio.sh && \
+RUN chmod +x /usr/local/bin/setup-audio-bridge.sh \
+    /usr/local/bin/start-pulseaudio.sh \
+    /usr/local/bin/start-audio-bridge.sh \
+    /usr/local/bin/integrate-audio-ui.sh \
+    /usr/local/bin/start-turn.sh \
+    /usr/local/bin/test-webrtc-websocket-audio.sh && \
     /usr/local/bin/setup-audio-bridge.sh && \
     /usr/local/bin/integrate-audio-ui.sh
 

--- a/ubuntu-kde-docker/start-audio-bridge.sh
+++ b/ubuntu-kde-docker/start-audio-bridge.sh
@@ -1,0 +1,20 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+PULSE_USER="${PULSE_USER:-${DEV_USERNAME:-devuser}}"
+PULSE_UID="${PULSE_UID:-$(id -u "$PULSE_USER" 2>/dev/null || echo 1000)}"
+RUNTIME_DIR="/run/user/$PULSE_UID"
+
+echo "Waiting for PulseAudio to be ready for AudioBridge..."
+for i in {1..20}; do
+  if su - "$PULSE_USER" -c "export XDG_RUNTIME_DIR=$RUNTIME_DIR; pactl info" >/dev/null 2>&1; then
+    echo "PulseAudio is ready. Starting AudioBridge."
+    exec /usr/bin/node /opt/audio-bridge/webrtc-audio-server.cjs
+  fi
+  echo "PulseAudio not ready for AudioBridge (attempt $i/20)" >&2
+  sleep 1
+done
+
+echo "PulseAudio failed to start for AudioBridge" >&2
+exit 1
+

--- a/ubuntu-kde-docker/supervisord.conf
+++ b/ubuntu-kde-docker/supervisord.conf
@@ -46,12 +46,12 @@ stdout_logfile=/var/log/supervisor/accounts-daemon.log
 stderr_logfile=/var/log/supervisor/accounts-daemon.log
 
 [program:pulseaudio]
-command=/bin/sh -c "sleep 10; export XDG_RUNTIME_DIR=/run/user/%(ENV_DEV_UID)s; export HOME=/home/%(ENV_DEV_USERNAME)s; export PULSE_RUNTIME_PATH=/run/user/%(ENV_DEV_UID)s/pulse; mkdir -p /run/user/%(ENV_DEV_UID)s/pulse; chown %(ENV_DEV_USERNAME)s:%(ENV_DEV_USERNAME)s /run/user/%(ENV_DEV_UID)s/pulse; exec /usr/bin/pulseaudio --daemonize=no --disallow-exit --exit-idle-time=-1 --system=false --file=/home/%(ENV_DEV_USERNAME)s/.config/pulse/default.pa"
+command=/usr/local/bin/start-pulseaudio.sh
 priority=25
 autostart=true
 autorestart=true
-user=%(ENV_DEV_USERNAME)s
-environment=HOME=/home/%(ENV_DEV_USERNAME)s,USER=%(ENV_DEV_USERNAME)s,XDG_RUNTIME_DIR=/run/user/%(ENV_DEV_UID)s,PULSE_RUNTIME_PATH=/run/user/%(ENV_DEV_UID)s/pulse,DEV_USERNAME=%(ENV_DEV_USERNAME)s,DEV_UID=%(ENV_DEV_UID)s
+user=root
+environment=DEV_USERNAME=%(ENV_DEV_USERNAME)s,DEV_UID=%(ENV_DEV_UID)s
 startretries=3
 startsecs=5
 stdout_logfile=/var/log/supervisor/pulseaudio.log
@@ -204,7 +204,7 @@ depends_on=noVNC
 exitcodes=0
 
 [program:AudioBridge]
-command=/usr/bin/node /opt/audio-bridge/webrtc-audio-server.cjs
+command=/usr/local/bin/start-audio-bridge.sh
 priority=25
 autostart=true
 autorestart=true


### PR DESCRIPTION
## Summary
- add pactl info health check to PulseAudio startup script
- gate AudioBridge startup on successful pactl response
- wire supervisor and Docker build to use new startup scripts

## Testing
- `npm test` *(fails: Cannot find package '@eslint/js')*


------
https://chatgpt.com/codex/tasks/task_b_6897143420d0832f8f92b98a6b8480cc