### PR TITLE
Add dev user to audio group for sound access

### DIFF
--- a/ubuntu-kde-docker/entrypoint.sh
+++ b/ubuntu-kde-docker/entrypoint.sh
@@ -235,6 +235,9 @@ fi
 getent group video >/dev/null || groupadd -r video
 getent group render >/dev/null || groupadd -r render
 usermod -aG sudo,ssl-cert,pulse-access,video,render "$DEV_USERNAME"
+# Allow access to sound devices
+getent group audio >/dev/null || groupadd -r audio
+usermod -aG audio "$DEV_USERNAME"
 
 # Ensure runtime variables match the actual user IDs
 DEV_UID="$(id -u "$DEV_USERNAME")"


### PR DESCRIPTION
## Summary
- Ensure the audio group exists and add the dev user to it for sound device access

## Testing
- `npm test`
- `docker build -t webtop-audio-test ubuntu-kde-docker` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_b_689724a71ca4832fb16c01c4041bd45f