### PR TITLE
Handle stale PulseAudio sockets and add TCP fallback

### DIFF
--- a/ubuntu-kde-docker/start-pulseaudio.sh
+++ b/ubuntu-kde-docker/start-pulseaudio.sh
@@ -35,9 +35,38 @@ chmod 700 "$RUNTIME_DIR"
 # 3. Remove stale PID files or instances
 rm -f "$PULSE_DIR"/*.pid 2>/dev/null || true
 pkill -u "$PULSE_UID" pulseaudio >/dev/null 2>&1 || true
+# PulseAudio's native UNIX socket path.  If a previous run crashed or exited
+# without cleaning up, the leftover file will block the daemon from binding to
+# the same address again, so ensure it is removed before startup.
+NATIVE_SOCKET="$PULSE_DIR/native"
+if [ -e "$NATIVE_SOCKET" ]; then
+  echo "Removing stale PulseAudio socket: $NATIVE_SOCKET"
+  rm -f "$NATIVE_SOCKET"
+fi
+
+# start_pulseaudio MODE
+#   $1 - desired transport: "unix" (default) uses only the native
+#       UNIX socket, while "tcp" loads module-native-protocol-tcp and
+#       disables the idle timeout so the daemon listens on localhost.
+# Launch PulseAudio as $PULSE_USER using the requested transport.  The
+# script calls this first with "unix"; if pactl cannot reach the daemon the
+# caller switches PA_MODE to "tcp" and invokes the function again to retry
+# over loopback TCP.
+start_pulseaudio() {
+  local mode="$1"
+  local cmd="pulseaudio -D --log-target=file:$LOGFILE"
+  if [ "$mode" = "tcp" ]; then
+    cmd="pulseaudio -D --exit-idle-time=-1 --load=module-native-protocol-tcp --log-target=file:$LOGFILE"
+  fi
+  su - "$PULSE_USER" -c "export XDG_RUNTIME_DIR=$RUNTIME_DIR; $cmd"
+}
 
 # 4. Start PulseAudio in daemon mode and log output
-su - "$PULSE_USER" -c "export XDG_RUNTIME_DIR=$RUNTIME_DIR; pulseaudio -D --log-target=file:$LOGFILE"
+# PA_MODE tracks which transport is currently active so later health checks
+# and logs use the correct connection string. We begin in "unix" mode and only
+# switch to "tcp" if the UNIX socket cannot be bound.
+PA_MODE="unix"
+start_pulseaudio "$PA_MODE"
 
 for i in {1..10}; do
   if grep -q 'Daemon startup complete' "$LOGFILE" || grep -q 'READY=1' "$LOGFILE"; then
@@ -52,30 +81,69 @@ if ! grep -q 'Daemon startup complete' "$LOGFILE" && ! grep -q 'READY=1' "$LOGFI
   exit 1
 fi
 
-# 5. Wait for pactl to report server info
-echo "Waiting for PulseAudio availability..."
-for i in {1..20}; do
-  if su - "$PULSE_USER" -c "export XDG_RUNTIME_DIR=$RUNTIME_DIR; pactl info" >/dev/null 2>&1; then
-    echo "pactl info succeeded."
-    break
-  fi
-  echo "PulseAudio not ready (attempt $i/20)" >&2
-  sleep 1
-done
+# wait_for_pactl SERVER_FLAG LABEL
+#   $1 - environment prefix passed to pactl (e.g. export XDG_RUNTIME_DIR=… or
+#       PULSE_SERVER=…) to select the transport being tested
+#   $2 - text label appended to log messages for clarity
+# Polls "pactl info" until it succeeds or times out, verifying the daemon is
+# reachable over the given transport.  The caller first probes the UNIX socket;
+# failure there triggers a restart in TCP mode and another call to this helper
+# with the appropriate PULSE_SERVER value.
+wait_for_pactl() {
+  local server_flag="$1"
+  local label="$2"
+  echo "Waiting for PulseAudio availability$label..."
+  for i in {1..20}; do
+    if su - "$PULSE_USER" -c "$server_flag pactl info" >/dev/null 2>&1; then
+      echo "pactl info succeeded$label."
+      return 0
+    fi
+    echo "PulseAudio not ready$label (attempt $i/20)" >&2
+    sleep 1
+  done
+  return 1
+}
 
-if ! su - "$PULSE_USER" -c "export XDG_RUNTIME_DIR=$RUNTIME_DIR; pactl info" >/dev/null 2>&1; then
-  echo "Failed to connect to PulseAudio with pactl info" >&2
-  echo "Check $LOGFILE for details" >&2
-  exit 1
+# Try connecting over the expected UNIX socket first. If pactl cannot reach the
+# daemon, assume the bind failed (e.g. another socket is already in use) and
+# restart in TCP mode.
+if ! wait_for_pactl "export XDG_RUNTIME_DIR=$RUNTIME_DIR;" ""; then
+  echo "Initial PulseAudio startup failed, retrying with TCP..." >&2
+  pkill -u "$PULSE_UID" pulseaudio >/dev/null 2>&1 || true
+  rm -f "$NATIVE_SOCKET" 2>/dev/null || true
+  # Switch to TCP fallback and record the mode so later steps know to use the
+  # network endpoint instead of the UNIX socket.
+  PA_MODE="tcp"
+  start_pulseaudio "$PA_MODE"
+  for i in {1..10}; do
+    if grep -q 'Daemon startup complete' "$LOGFILE" || grep -q 'READY=1' "$LOGFILE"; then
+      echo "PulseAudio reported successful startup."
+      break
+    fi
+    sleep 1
+  done
+  wait_for_pactl "PULSE_SERVER=tcp:127.0.0.1:4713" " over TCP" || {
+    echo "Failed to connect to PulseAudio with pactl info" >&2
+    echo "Check $LOGFILE for details" >&2
+    exit 1
+  }
 fi
 
 # 6. Health check for sinks/sources
 echo "Performing PulseAudio health check..."
-SINKS=$(su - "$PULSE_USER" -c "export XDG_RUNTIME_DIR=$RUNTIME_DIR; pactl list short sinks" 2>/dev/null)
+# PA_MODE decides which environment variables to pass so pactl contacts the
+# daemon over the same transport we confirmed above.
+if [ "$PA_MODE" = "tcp" ]; then
+  PACTL_PREFIX="PULSE_SERVER=tcp:127.0.0.1:4713"
+else
+  PACTL_PREFIX="export XDG_RUNTIME_DIR=$RUNTIME_DIR;"
+fi
+SINKS=$(su - "$PULSE_USER" -c "$PACTL_PREFIX pactl list short sinks" 2>/dev/null)
 if [ -z "$SINKS" ]; then
   echo "Health check failed: no PulseAudio sinks found" >&2
   exit 1
 fi
 echo "$SINKS"
 
-echo "PulseAudio is ready."
+echo "PulseAudio is ready using $PA_MODE."
+echo "PulseAudio bound to $PA_MODE" >> "$LOGFILE"

--- a/ubuntu-kde-docker/test/start-pulseaudio.test.cjs
+++ b/ubuntu-kde-docker/test/start-pulseaudio.test.cjs
@@ -1,0 +1,123 @@
+const test = require('node:test');
+const assert = require('node:assert');
+const fs = require('fs');
+const path = require('path');
+const os = require('os');
+const net = require('net');
+const { spawnSync } = require('child_process');
+
+function writeStub(dir, name, content) {
+  const file = path.join(dir, name);
+  fs.writeFileSync(file, content);
+  fs.chmodSync(file, 0o755);
+}
+
+test('falls back to TCP when UNIX socket unavailable', async (t) => {
+  const stubDir = fs.mkdtempSync(path.join(os.tmpdir(), 'pa-stub-'));
+  const stubLog = path.join(stubDir, 'stub.log');
+  const logFile = path.join(stubDir, 'pa.log');
+
+  // stub commands
+  writeStub(stubDir, 'dpkg', '#!/bin/bash\nexit 0');
+  writeStub(stubDir, 'id', '#!/bin/bash\nif [ "$1" = "-u" ]; then echo 1000; exit 0; fi\nif [ "$1" = "-nG" ]; then echo audio; exit 0; fi\nexit 0');
+  writeStub(stubDir, 'chown', '#!/bin/bash\nexit 0');
+  writeStub(stubDir, 'su', '#!/bin/bash\necho "su $@" >>"$STUB_OUT"\ncmd="$4"\nbash -c "$cmd"');
+  writeStub(stubDir, 'pulseaudio', '#!/bin/bash\necho "pulseaudio $@" >>"$STUB_OUT"\necho "Daemon startup complete" >>"$LOGFILE"\nexit 0');
+  writeStub(stubDir, 'pactl', '#!/bin/bash\necho "pactl $@" >>"$STUB_OUT"\nif [ "$1" = "list" ] && [ "$3" = "sinks" ]; then echo "1\tstub_sink"; exit 0; fi\nif [ -n "$PULSE_SERVER" ]; then exit 0; else exit 1; fi');
+  writeStub(stubDir, 'pkill', '#!/bin/bash\necho "pkill $@" >>"$STUB_OUT"');
+  writeStub(stubDir, 'sleep', '#!/bin/bash\n:');
+
+  // dummy native socket
+  const runtimeDir = path.join('/run/user', '1000', 'pulse');
+  fs.mkdirSync(runtimeDir, { recursive: true });
+  const sockPath = path.join(runtimeDir, 'native');
+  try { fs.unlinkSync(sockPath); } catch {}
+  const server = net.createServer().listen(sockPath);
+  t.after(async () => {
+    await new Promise((resolve) => server.close(resolve));
+    try {
+      fs.unlinkSync(sockPath);
+    } catch {}
+  });
+
+  const script = path.resolve(__dirname, '..', 'start-pulseaudio.sh');
+  const result = spawnSync('/bin/bash', [script], {
+    env: {
+      PATH: `${stubDir}:${process.env.PATH}`,
+      PULSE_USER: 'stubuser',
+      PULSE_UID: '1000',
+      LOGFILE: logFile,
+      PULSE_LOGFILE: logFile,
+      STUB_OUT: stubLog,
+    },
+    encoding: 'utf8',
+  });
+  assert.strictEqual(result.status, 0);
+  const log = fs.readFileSync(logFile, 'utf8');
+  assert.match(log, /PulseAudio bound to tcp/);
+  const stub = fs.readFileSync(stubLog, 'utf8');
+  assert.match(stub, /pulseaudio -D --log-target=file:/);
+  assert.match(stub, /pulseaudio -D --exit-idle-time=-1 --load=module-native-protocol-tcp --log-target=file:/);
+  assert.ok(!fs.existsSync(sockPath));
+});
+
+test('uses UNIX socket when available', async (t) => {
+  const stubDir = fs.mkdtempSync(path.join(os.tmpdir(), 'pa-stub-'));
+  const stubLog = path.join(stubDir, 'stub.log');
+  const logFile = path.join(stubDir, 'pa.log');
+
+  // stub commands
+  writeStub(stubDir, 'dpkg', '#!/bin/bash\nexit 0');
+  writeStub(
+    stubDir,
+    'id',
+    '#!/bin/bash\nif [ "$1" = "-u" ]; then echo 1000; exit 0; fi\nif [ "$1" = "-nG" ]; then echo audio; exit 0; fi\nexit 0'
+  );
+  writeStub(stubDir, 'chown', '#!/bin/bash\nexit 0');
+  writeStub(
+    stubDir,
+    'su',
+    '#!/bin/bash\necho "su $@" >>"$STUB_OUT"\ncmd="$4"\nbash -c "$cmd"'
+  );
+  writeStub(
+    stubDir,
+    'pulseaudio',
+    '#!/bin/bash\necho "pulseaudio $@" >>"$STUB_OUT"\necho "Daemon startup complete" >>"$LOGFILE"\nexit 0'
+  );
+  writeStub(
+    stubDir,
+    'pactl',
+    '#!/bin/bash\necho "pactl $@" >>"$STUB_OUT"\nif [ "$1" = "list" ] && [ "$3" = "sinks" ]; then echo "1\tstub_sink"; exit 0; fi\nexit 0'
+  );
+  writeStub(stubDir, 'pkill', '#!/bin/bash\necho "pkill $@" >>"$STUB_OUT"');
+  writeStub(stubDir, 'sleep', '#!/bin/bash\n:');
+
+  // ensure no native socket exists
+  const runtimeDir = path.join('/run/user', '1000', 'pulse');
+  fs.mkdirSync(runtimeDir, { recursive: true });
+  const sockPath = path.join(runtimeDir, 'native');
+  try { fs.unlinkSync(sockPath); } catch {}
+
+  const script = path.resolve(__dirname, '..', 'start-pulseaudio.sh');
+  const result = spawnSync('/bin/bash', [script], {
+    env: {
+      PATH: `${stubDir}:${process.env.PATH}`,
+      PULSE_USER: 'stubuser',
+      PULSE_UID: '1000',
+      LOGFILE: logFile,
+      PULSE_LOGFILE: logFile,
+      STUB_OUT: stubLog,
+    },
+    encoding: 'utf8',
+  });
+  assert.strictEqual(result.status, 0);
+  const log = fs.readFileSync(logFile, 'utf8');
+  assert.match(log, /PulseAudio bound to unix/);
+  const stub = fs.readFileSync(stubLog, 'utf8');
+  const pulseaudioLines = stub
+    .split('\n')
+    .filter((line) => line.startsWith('pulseaudio'));
+  assert.strictEqual(pulseaudioLines.length, 1);
+  assert.ok(!pulseaudioLines[0].includes('module-native-protocol-tcp'));
+  assert.match(stub, /pactl list short sinks/);
+});


### PR DESCRIPTION
## Summary
- remove stale PulseAudio native sockets before startup
- retry with TCP server if Unix socket startup fails
- log whether PulseAudio bound to Unix or TCP
- add tests to ensure TCP fallback when socket blocked and Unix mode when socket free
- ensure tests clean up dummy native socket after closing server
- document cleanup, fallback detection, and PA_MODE semantics
- clarify helper functions and TCP fallback control flow
- expand comments describing parameters and retry logic of start_pulseaudio and wait_for_pactl

## Testing
- `npm test`
- `node --test ubuntu-kde-docker/test/start-pulseaudio.test.cjs`


------
https://chatgpt.com/codex/tasks/task_b_689731d499bc832f990dab572527100b