### PR TITLE
Refine audio service startup in supervisord

### DIFF
--- a/ubuntu-kde-docker/supervisord.conf
+++ b/ubuntu-kde-docker/supervisord.conf
@@ -49,13 +49,14 @@ stderr_logfile=/var/log/supervisor/accounts-daemon.log
 command=/usr/local/bin/start-pulseaudio.sh
 priority=25
 autostart=true
-autorestart=true
+autorestart=unexpected
 user=root
 environment=DEV_USERNAME=%(ENV_DEV_USERNAME)s,DEV_UID=%(ENV_DEV_UID)s
 startretries=3
 startsecs=5
 stdout_logfile=/var/log/supervisor/pulseaudio.log
 stderr_logfile=/var/log/supervisor/pulseaudio.log
+exitcodes=0
 
 [program:KDE]
 command=/bin/sh -c "sleep 15; export DISPLAY=:1; export XDG_RUNTIME_DIR=/run/user/%(ENV_DEV_UID)s; export HOME=/home/%(ENV_DEV_USERNAME)s; exec startplasma-x11"
@@ -152,11 +153,12 @@ stderr_logfile=/var/log/supervisor/audio-monitor.log
 command=/usr/local/bin/start-turn.sh
 priority=24
 autostart=true
-autorestart=true
+autorestart=unexpected
 stopsignal=TERM
 user=root
 stdout_logfile=/var/log/supervisor/turnserver.log
 stderr_logfile=/var/log/supervisor/turnserver.log
+exitcodes=0
 
 [program:ServiceHealth]
 command=/bin/sh -c "sleep 75; /usr/local/bin/service-health.sh smart-monitor"
@@ -173,7 +175,7 @@ stdout_logfile=/var/log/supervisor/health.log
 stderr_logfile=/var/log/supervisor/health.log
 
 [program:CreateVirtualAudioDevices]
-command=/bin/bash /usr/local/bin/create-virtual-audio-devices.sh
+command=/bin/sh -c 'sleep 10; /bin/bash /usr/local/bin/create-virtual-audio-devices.sh'
 user=root
 autostart=true
 autorestart=false
@@ -183,7 +185,6 @@ stdout_logfile=/var/log/supervisor/audio-devices.log
 stderr_logfile=/var/log/supervisor/audio-devices.log
 environment=DEV_USERNAME="%(ENV_DEV_USERNAME)s",DEV_UID="%(ENV_DEV_UID)s",DEV_GID="%(ENV_DEV_GID)s",XDG_RUNTIME_DIR="/run/user/%(ENV_DEV_UID)s"
 priority=400
-depends_on=pulseaudio
 exitcodes=0
 
 [program:SetupDesktop]
@@ -191,7 +192,7 @@ command=/bin/sh -c 'sleep 55; /usr/local/bin/setup-desktop.sh'
 priority=50
 
 [program:SetupUniversalAudio]
-command=/bin/bash /usr/local/bin/setup-universal-audio.sh
+command=/bin/sh -c 'sleep 20; /bin/bash /usr/local/bin/setup-universal-audio.sh'
 user=root
 autostart=true
 autorestart=false
@@ -200,18 +201,17 @@ startretries=0
 stdout_logfile=/var/log/supervisor/universal-audio.log
 stderr_logfile=/var/log/supervisor/universal-audio.log
 priority=405
-depends_on=noVNC
 exitcodes=0
 
 [program:AudioBridge]
-command=/usr/local/bin/start-audio-bridge.sh
+command=/bin/sh -c 'sleep 20; /usr/local/bin/start-audio-bridge.sh'
 priority=25
 autostart=true
-autorestart=true
+autorestart=unexpected
 stopsignal=TERM
 user=root
 startsecs=20
-depends_on=pulseaudio
+exitcodes=0
 environment=WEBRTC_PORT=8080,AUDIO_PORT=8080,WEBRTC_STUN_SERVER="%(ENV_WEBRTC_STUN_SERVER)s",WEBRTC_TURN_SERVER="%(ENV_WEBRTC_TURN_SERVER)s",WEBRTC_TURN_USERNAME="%(ENV_WEBRTC_TURN_USERNAME)s",WEBRTC_TURN_PASSWORD="%(ENV_WEBRTC_TURN_PASSWORD)s"
 stdout_logfile=/var/log/supervisor/audio-bridge.log
 stderr_logfile=/var/log/supervisor/audio-bridge.log


### PR DESCRIPTION
## Summary
- replace `depends_on` for audio services with sleep-based start delays
- tighten exitcode and autorestart settings to avoid restart loops

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_68973e6c1f5c832fa3fcf0998fa8b143