### PR TITLE
feat: allow dev user override in audio diagnostic

### DIFF
--- a/ubuntu-kde-docker/diagnostic-and-fix.sh
+++ b/ubuntu-kde-docker/diagnostic-and-fix.sh
@@ -1,9 +1,15 @@
 #!/bin/bash
 # diagnostic-and-fix.sh: Automatic audio diagnostic and fix script for WebTop container
+#
+# Usage:
+#   DEV_UID=<uid> DEV_USERNAME=<user> ./diagnostic-and-fix.sh
 set -euo pipefail
 
-# Assume the user's PulseAudio runtime directory is available
-export XDG_RUNTIME_DIR="${XDG_RUNTIME_DIR:-/run/user/$(id -u)}"
+DEV_USERNAME="${DEV_USERNAME:-devuser}"
+DEV_UID="${DEV_UID:-$(id -u "$DEV_USERNAME" 2>/dev/null || echo 1000)}"
+
+# Use the specified user's PulseAudio runtime directory
+export XDG_RUNTIME_DIR="/run/user/${DEV_UID}"
 
 LOG_FILE="${LOG_FILE:-/tmp/audio_diagnostic.log}"
 : >"$LOG_FILE"


### PR DESCRIPTION
## Summary
- allow passing DEV_UID and DEV_USERNAME to diagnostic script
- set XDG_RUNTIME_DIR based on provided DEV_UID before PulseAudio commands
- document usage

## Testing
- `npm test`
- `node --test ubuntu-kde-docker/test/diagnostic-and-fix.test.cjs`


------
https://chatgpt.com/codex/tasks/task_b_68974c61c5e4832fb7536bfbb4b0e25d