### PR TITLE
Retry audio bridge with TCP and backoff

### DIFF
--- a/ubuntu-kde-docker/start-audio-bridge.sh
+++ b/ubuntu-kde-docker/start-audio-bridge.sh
@@ -11,7 +11,9 @@ attempt=1
 max_attempts=5
 sleep_time=1
 
+# Retry until PulseAudio responds, using exponential backoff
 while [ "$attempt" -le "$max_attempts" ]; do
+  # Test both the Unix socket (via XDG_RUNTIME_DIR) and TCP port 4713
   if su - "$PULSE_USER" -c "export XDG_RUNTIME_DIR=$RUNTIME_DIR; pactl info" >/dev/null 2>&1 || \
      su - "$PULSE_USER" -c "pactl -s tcp:localhost:4713 info" >/dev/null 2>&1; then
     echo "PulseAudio is ready. Starting AudioBridge."
@@ -19,6 +21,7 @@ while [ "$attempt" -le "$max_attempts" ]; do
   fi
 
   echo "PulseAudio not ready for AudioBridge (attempt $attempt/$max_attempts)" >&2
+  # Fall back to starting PulseAudio before the next attempt
   "$SCRIPT_DIR/start-pulseaudio.sh" >/dev/null 2>&1 || true
   sleep "$sleep_time"
   sleep_time=$((sleep_time * 2))

--- a/ubuntu-kde-docker/start-audio-bridge.sh
+++ b/ubuntu-kde-docker/start-audio-bridge.sh
@@ -4,15 +4,25 @@ set -euo pipefail
 PULSE_USER="${PULSE_USER:-${DEV_USERNAME:-devuser}}"
 PULSE_UID="${PULSE_UID:-$(id -u "$PULSE_USER" 2>/dev/null || echo 1000)}"
 RUNTIME_DIR="/run/user/$PULSE_UID"
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 
 echo "Waiting for PulseAudio to be ready for AudioBridge..."
-for i in {1..20}; do
-  if su - "$PULSE_USER" -c "export XDG_RUNTIME_DIR=$RUNTIME_DIR; pactl info" >/dev/null 2>&1; then
+attempt=1
+max_attempts=5
+sleep_time=1
+
+while [ "$attempt" -le "$max_attempts" ]; do
+  if su - "$PULSE_USER" -c "export XDG_RUNTIME_DIR=$RUNTIME_DIR; pactl info" >/dev/null 2>&1 || \
+     su - "$PULSE_USER" -c "pactl -s tcp:localhost:4713 info" >/dev/null 2>&1; then
     echo "PulseAudio is ready. Starting AudioBridge."
     exec /usr/bin/node /opt/audio-bridge/webrtc-audio-server.cjs
   fi
-  echo "PulseAudio not ready for AudioBridge (attempt $i/20)" >&2
-  sleep 1
+
+  echo "PulseAudio not ready for AudioBridge (attempt $attempt/$max_attempts)" >&2
+  "$SCRIPT_DIR/start-pulseaudio.sh" >/dev/null 2>&1 || true
+  sleep "$sleep_time"
+  sleep_time=$((sleep_time * 2))
+  attempt=$((attempt + 1))
 done
 
 echo "PulseAudio failed to start for AudioBridge" >&2

--- a/ubuntu-kde-docker/test/start-audio-bridge.test.cjs
+++ b/ubuntu-kde-docker/test/start-audio-bridge.test.cjs
@@ -1,0 +1,78 @@
+const test = require('node:test');
+const assert = require('node:assert');
+const fs = require('fs');
+const os = require('os');
+const path = require('path');
+const { spawnSync } = require('child_process');
+
+function writeStub(dir, name, content) {
+  const file = path.join(dir, name);
+  fs.writeFileSync(file, content);
+  fs.chmodSync(file, 0o755);
+}
+
+test('retries and calls start-pulseaudio with exponential backoff', { concurrency: false }, (t) => {
+  const tmp = fs.mkdtempSync(path.join(os.tmpdir(), 'sab-'));
+  const log = path.join(tmp, 'stub.log');
+
+  // Copy script under test and stub start-pulseaudio.sh in same dir.
+  const scriptSrc = path.resolve(__dirname, '..', 'start-audio-bridge.sh');
+  const script = path.join(tmp, 'start-audio-bridge.sh');
+  fs.copyFileSync(scriptSrc, script);
+  fs.chmodSync(script, 0o755);
+  writeStub(tmp, 'start-pulseaudio.sh', '#!/bin/bash\necho "start-pulseaudio" >>"$STUB_OUT"');
+
+  // Stub utilities used by the script.
+  writeStub(tmp, 'su', '#!/bin/bash\ncmd="$4"\nbash -c "$cmd"');
+  writeStub(tmp, 'pactl', '#!/bin/bash\nexit 1');
+  writeStub(tmp, 'sleep', '#!/bin/bash\necho "sleep $1" >>"$STUB_OUT"');
+
+  const result = spawnSync('/bin/bash', [script], {
+    env: { PATH: `${tmp}:${process.env.PATH}`, STUB_OUT: log, PULSE_USER: 'stub', PULSE_UID: '1000' },
+    encoding: 'utf8',
+  });
+
+  assert.notStrictEqual(result.status, 0);
+  const stub = fs.readFileSync(log, 'utf8').trim().split('\n');
+  const sleeps = stub.filter((l) => l.startsWith('sleep')).map((l) => l.split(' ')[1]);
+  assert.deepStrictEqual(sleeps, ['1', '2', '4', '8', '16']);
+  const starts = stub.filter((l) => l.startsWith('start-pulseaudio'));
+  assert.strictEqual(starts.length, 5);
+});
+
+test('exits once PulseAudio is reachable over TCP', { concurrency: false }, (t) => {
+  const tmp = fs.mkdtempSync(path.join(os.tmpdir(), 'sab-'));
+  const log = path.join(tmp, 'stub.log');
+
+  const scriptSrc = path.resolve(__dirname, '..', 'start-audio-bridge.sh');
+  const script = path.join(tmp, 'start-audio-bridge.sh');
+  fs.copyFileSync(scriptSrc, script);
+  fs.chmodSync(script, 0o755);
+  writeStub(tmp, 'start-pulseaudio.sh', '#!/bin/bash\necho "start-pulseaudio" >>"$STUB_OUT"');
+
+  writeStub(tmp, 'su', '#!/bin/bash\ncmd="$4"\nbash -c "$cmd"');
+  writeStub(
+    tmp,
+    'pactl',
+    '#!/bin/bash\nif [ "$1" = "info" ]; then exit 1; fi\nif [ "$1" = "-s" ] && [ "$2" = "tcp:localhost:4713" ] && [ "$3" = "info" ]; then exit 0; fi\nexit 1'
+  );
+  writeStub(tmp, 'sleep', '#!/bin/bash\necho "sleep $1" >>"$STUB_OUT"');
+
+  writeStub(tmp, 'node', '#!/bin/bash\necho "node $@" >>"$STUB_OUT"');
+  const nodePath = '/usr/bin/node';
+  fs.copyFileSync(path.join(tmp, 'node'), nodePath);
+  t.after(() => {
+    try { fs.unlinkSync(nodePath); } catch {}
+  });
+
+  const result = spawnSync('/bin/bash', [script], {
+    env: { PATH: `${tmp}:${process.env.PATH}`, STUB_OUT: log, PULSE_USER: 'stub', PULSE_UID: '1000' },
+    encoding: 'utf8',
+  });
+
+  assert.strictEqual(result.status, 0);
+  const stub = fs.readFileSync(log, 'utf8');
+  assert.ok(!stub.includes('start-pulseaudio'));
+  assert.ok(!stub.includes('sleep'));
+  assert.match(stub, /node \/opt\/audio-bridge\/webrtc-audio-server.cjs/);
+});


### PR DESCRIPTION
## Summary
- Retry audio bridge over Unix or TCP PulseAudio connections
- Start PulseAudio on failure and retry with exponential backoff

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_b_68974db27098832fae045d1c48e991cc