### PR TITLE
Skip Android module check in container environments

### DIFF
--- a/ubuntu-kde-docker/check-android-modules.sh
+++ b/ubuntu-kde-docker/check-android-modules.sh
@@ -2,6 +2,13 @@
 # Pre-check for Android kernel modules needed by Waydroid
 set -e
 
+# Skip checks when running in a container
+if [ -n "$CONTAINER" ] || [ -f /.dockerenv ] || [ -f /.containerenv ] \
+   || grep -qaE '(docker|lxc|kubepods|containerd|podman)' /proc/1/cgroup; then
+    echo "Warning: Detected container environment; skipping Android kernel module checks." >&2
+    exit 0
+fi
+
 missing=()
 for mod in binder_linux ashmem_linux; do
     if ! lsmod | grep -q "$mod"; then


### PR DESCRIPTION
## Summary
- detect container environments in `check-android-modules.sh`
- skip Android kernel module validation when running inside containers

## Testing
- `./ubuntu-kde-docker/check-android-modules.sh && echo OK`
- `npm test >/tmp/unit.log && tail -n 20 /tmp/unit.log && echo OK`

------
https://chatgpt.com/codex/tasks/task_b_68975896fa44832f8e96eb18d338474c