### PR TITLE
fix: remove conflicting PulseAudio configs

### DIFF
--- a/ubuntu-kde-docker/fix-audio-startup.sh
+++ b/ubuntu-kde-docker/fix-audio-startup.sh
@@ -45,9 +45,13 @@ fi
 
 # Create optimized PulseAudio client configuration (runtime only)
 if [ "$IS_RUNTIME" = true ]; then
+    # Remove any user-provided PulseAudio server configuration which can
+    # prevent the daemon from autospawning. Rely on system defaults instead.
+    rm -f "/home/${DEV_USERNAME}/.config/pulse/default.pa" 2>/dev/null || true
+
     cat <<EOF > "/home/${DEV_USERNAME}/.config/pulse/client.conf"
 # Container-optimized PulseAudio client configuration
-default-server = unix:/run/user/${DEV_UID}/pulse/native
+autospawn = yes
 enable-shm = no
 enable-memfd = no
 auto-connect-localhost = yes

--- a/ubuntu-kde-docker/setup-audio.sh
+++ b/ubuntu-kde-docker/setup-audio.sh
@@ -68,8 +68,8 @@ load-module module-stream-restore
 load-module module-card-restore
 load-module module-augment-properties
 
-# Load native protocol first (local socket)
-load-module module-native-protocol-unix auth-anonymous=1 socket=/run/user/${DEV_UID}/pulse/native
+# Load native protocol first (use runtime directory for socket)
+load-module module-native-protocol-unix auth-anonymous=1
 
 # Enable TCP module for remote audio access (VNC)
 load-module module-native-protocol-tcp auth-anonymous=1 port=4713 listen=0.0.0.0

--- a/ubuntu-kde-docker/supervisord.conf
+++ b/ubuntu-kde-docker/supervisord.conf
@@ -46,7 +46,7 @@ stdout_logfile=/var/log/supervisor/accounts-daemon.log
 stderr_logfile=/var/log/supervisor/accounts-daemon.log
 
 [program:pulseaudio]
-command=/bin/sh -c "/usr/local/bin/fix-pulseaudio.sh && /usr/local/bin/start-pulseaudio.sh"
+command=/usr/local/bin/start-pulseaudio.sh
 priority=25
 autostart=true
 autorestart=unexpected


### PR DESCRIPTION
## Summary
- remove user `default.pa` and default server to allow PulseAudio autospawn
- dynamically detect user UID in noVNC audio fix script
- supervise PulseAudio startup with single script
- drop hardcoded socket path from runtime `default.pa`

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_6897769a1774832fb639f35e4b5e133a