### PR TITLE
Fix PulseAudio supervision for hardware-free containers

### DIFF
--- a/ubuntu-kde-docker/start-audio-bridge.sh
+++ b/ubuntu-kde-docker/start-audio-bridge.sh
@@ -6,22 +6,29 @@ PULSE_UID="${PULSE_UID:-$(id -u "$PULSE_USER" 2>/dev/null || echo 1000)}"
 RUNTIME_DIR="/run/user/$PULSE_UID"
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 
+run_as_pulse_user() {
+  if [ "$(id -u)" -eq "$PULSE_UID" ]; then
+    bash -lc "$1"
+  else
+    su - "$PULSE_USER" -c "$1"
+  fi
+}
+
 echo "Waiting for PulseAudio to be ready for AudioBridge..."
 attempt=1
 max_attempts=5
 sleep_time=1
 
-# Retry until PulseAudio responds, using exponential backoff
 while [ "$attempt" -le "$max_attempts" ]; do
-  # Test both the Unix socket (via XDG_RUNTIME_DIR) and TCP port 4713
-  if su - "$PULSE_USER" -c "export XDG_RUNTIME_DIR=$RUNTIME_DIR; pactl info" >/dev/null 2>&1 || \
-     su - "$PULSE_USER" -c "pactl -s tcp:localhost:4713 info" >/dev/null 2>&1; then
-    echo "PulseAudio is ready. Starting AudioBridge."
-    exec su - "$PULSE_USER" -c "export XDG_RUNTIME_DIR=$RUNTIME_DIR PULSE_RUNTIME_PATH=$RUNTIME_DIR/pulse PULSE_SERVER=unix:$RUNTIME_DIR/pulse/native; node /opt/audio-bridge/webrtc-audio-server.cjs"
+  if run_as_pulse_user "export XDG_RUNTIME_DIR=$RUNTIME_DIR; pactl info" >/dev/null 2>&1; then
+    echo "PulseAudio is ready on UNIX socket. Starting AudioBridge."
+    run_as_pulse_user "export XDG_RUNTIME_DIR=$RUNTIME_DIR PULSE_RUNTIME_PATH=$RUNTIME_DIR/pulse PULSE_SERVER=unix:$RUNTIME_DIR/pulse/native; exec node /opt/audio-bridge/webrtc-audio-server.cjs"
+  elif run_as_pulse_user "pactl -s tcp:localhost:4713 info" >/dev/null 2>&1; then
+    echo "PulseAudio is ready over TCP. Starting AudioBridge."
+    run_as_pulse_user "PULSE_SERVER=tcp:127.0.0.1:4713 exec node /opt/audio-bridge/webrtc-audio-server.cjs"
   fi
 
   echo "PulseAudio not ready for AudioBridge (attempt $attempt/$max_attempts)" >&2
-  # Fall back to starting PulseAudio before the next attempt
   "$SCRIPT_DIR/start-pulseaudio.sh" >/dev/null 2>&1 || true
   sleep "$sleep_time"
   sleep_time=$((sleep_time * 2))
@@ -30,4 +37,3 @@ done
 
 echo "PulseAudio failed to start for AudioBridge" >&2
 exit 1
-

--- a/ubuntu-kde-docker/supervisord.conf
+++ b/ubuntu-kde-docker/supervisord.conf
@@ -50,8 +50,8 @@ command=/usr/local/bin/start-pulseaudio.sh
 priority=25
 autostart=true
 autorestart=unexpected
-user=root
-environment=DEV_USERNAME=%(ENV_DEV_USERNAME)s,DEV_UID=%(ENV_DEV_UID)s
+user=%(ENV_DEV_USERNAME)s
+environment=HOME=/home/%(ENV_DEV_USERNAME)s,XDG_RUNTIME_DIR=/run/user/%(ENV_DEV_UID)s,PULSE_RUNTIME_PATH=/run/user/%(ENV_DEV_UID)s/pulse,DEV_USERNAME=%(ENV_DEV_USERNAME)s,DEV_UID=%(ENV_DEV_UID)s
 startretries=3
 startsecs=5
 stdout_logfile=/var/log/supervisor/pulseaudio.log

--- a/ubuntu-kde-docker/system.pa
+++ b/ubuntu-kde-docker/system.pa
@@ -6,8 +6,6 @@ load-module module-stream-restore
 load-module module-card-restore
 
 # Load audio drivers
-load-module module-udev-detect
-load-module module-detect
 
 # Load network modules
 load-module module-native-protocol-unix auth-anonymous=1


### PR DESCRIPTION
## Summary
- run PulseAudio under the dev user with proper runtime environment
- strip hardware detection modules from system.pa for software-only audio
- make AudioBridge respect Unix or TCP PulseAudio endpoints

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_689780851108832f8d4590f3ce3b617f