### PR TITLE
docs: add audio diagnostics guide

### DIFF
--- a/ubuntu-kde-docker/README_AUDIO.md
+++ b/ubuntu-kde-docker/README_AUDIO.md
@@ -77,6 +77,8 @@ Desktop Apps → PulseAudio → Virtual Sink → Audio Bridge → WebSocket → 
 
 ## Troubleshooting
 
+For interactive debug tools and self-tests, see [docs/AUDIO_DIAGNOSTICS.md](docs/AUDIO_DIAGNOSTICS.md).
+
 ### No Audio in Browser
 1. Check that audio bridge is running: `docker logs webtop-kde | grep "Audio bridge"`
 2. Verify WebSocket connection in browser console
@@ -119,3 +121,7 @@ export PULSE_RUNTIME_PATH=/tmp/pulse-socket
 - Audio bridge only accepts connections from the same host
 - No authentication required (intended for local development)
 - WebSocket connections are not encrypted (use HTTPS for production)
+
+## See Also
+
+- [Audio Diagnostics Guide](docs/AUDIO_DIAGNOSTICS.md)

--- a/ubuntu-kde-docker/TROUBLESHOOTING.md
+++ b/ubuntu-kde-docker/TROUBLESHOOTING.md
@@ -4,6 +4,8 @@
 
 ### 🎵 Audio Issues
 
+For interactive diagnostics and self-tests, see [docs/AUDIO_DIAGNOSTICS.md](docs/AUDIO_DIAGNOSTICS.md).
+
 #### "No output or input devices found" in KDE
 **Cause**: Virtual audio devices not created or PulseAudio misconfigured
 

--- a/ubuntu-kde-docker/docs/AUDIO_DIAGNOSTICS.md
+++ b/ubuntu-kde-docker/docs/AUDIO_DIAGNOSTICS.md
@@ -1,0 +1,85 @@
+# Audio Diagnostics
+
+This guide explains how to debug and validate the WebTop audio pipeline.
+
+## Enable Debug Mode
+
+Append `?debug=1` to the audio player's URL to activate diagnostic tools:
+
+```bash
+http://localhost:8080/audio-player.html?debug=1
+```
+
+Debug mode displays a heads-up display (HUD) and enables self-test controls.
+
+**Troubleshooting:** If the HUD does not appear, verify the query string and reload the page. Some browsers cache aggressively; use a hard refresh.
+
+## Real-Time HUD Metrics
+
+With debug mode enabled, a floating HUD shows:
+
+- Stream latency and buffer usage
+- Sample rate and channel layout
+- RMS level meters for speakers and microphone
+
+Use the HUD to monitor audio levels while playing media or speaking.
+
+**Troubleshooting:** If RMS meters stay at zero, confirm that audio is playing and that the correct devices are selected inside the container.
+
+## Built-In Self-Tests
+
+### Beep Test
+Produces a short tone to confirm speaker output.
+
+**Usage:** Click **Beep** in the debug panel.
+
+**Troubleshooting:** If no sound is heard, ensure the volume is up and the audio bridge is connected.
+
+### Unlock Audio
+Initializes the audio context for browsers that block autoplay.
+
+**Usage:** Click **Unlock Audio** before starting tests.
+
+**Troubleshooting:** If the button has no effect, interact with the page (e.g., click anywhere) and try again. Some browsers require user interaction before sound can play.
+
+### Format Validation
+Confirms that the browser accepts the 44.1kHz 16-bit stereo PCM format used by the bridge.
+
+**Usage:** Click **Validate Format**.
+
+**Troubleshooting:** If validation fails, check browser console logs and ensure the browser supports standard PCM streams.
+
+### Loopback Test
+Routes microphone input back to the speakers to test end-to-end audio flow.
+
+**Usage:** Click **Loopback** and speak into the microphone.
+
+**Troubleshooting:** If nothing is heard, allow microphone access and verify that a valid input device is selected.
+
+## WebSocket Diagnostics
+
+The debug HUD tracks WebSocket details:
+
+- Connection state (connecting, open, closed)
+- Round-trip latency in milliseconds
+- Bytes sent and received
+
+**Usage:** Watch the **WebSocket** section of the HUD while audio is streaming.
+
+**Troubleshooting:** High latency or frozen byte counters may indicate network issues or blocked ports. Check browser developer tools and server logs.
+
+## Export Debug Report
+
+Click **Export Report** to download a ZIP containing logs, metrics, and configuration information.
+
+**Usage:**
+1. Enable debug mode.
+2. Click **Export Report** in the debug panel.
+
+**Troubleshooting:** If no file downloads, allow pop-ups or try a different browser. Ensure the page has permission to trigger downloads.
+
+## See Also
+
+- [Authentication & Security Guide](AUTHENTICATION.md)
+- [Multi-Container Deployment Guide](MULTI_CONTAINER.md)
+- [Audio System Overview](../README_AUDIO.md)

--- a/ubuntu-kde-docker/docs/AUTHENTICATION.md
+++ b/ubuntu-kde-docker/docs/AUTHENTICATION.md
@@ -496,3 +496,7 @@ echo "Domain: https://${CLIENT_DOMAIN}"
 ```
 
 This authentication system provides enterprise-grade security for marketing agency deployments while maintaining ease of use and management.
+## Related Documentation
+
+- [Audio Diagnostics](AUDIO_DIAGNOSTICS.md)
+


### PR DESCRIPTION
## Summary
- document audio debug tools and self-tests in AUDIO_DIAGNOSTICS.md
- link to new diagnostics guide from authentication, audio overview, and troubleshooting docs
- add further reading link from audio README to audio diagnostics guide

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_b_68991435d2e4832f9bcd13882e8762a4