### PR TITLE
docs: reference audio diagnostics guide

### DIFF
--- a/ubuntu-kde-docker/AUDIO_DIAGNOSTICS.md
+++ b/ubuntu-kde-docker/AUDIO_DIAGNOSTICS.md
@@ -1,0 +1,19 @@
+# Audio Diagnostics Guide
+
+This guide provides commands to verify and troubleshoot the audio pipeline inside the Ubuntu KDE container.
+
+## Quick Checks
+
+- Run `./audio-validation.sh` inside the container to verify virtual audio devices.
+- Use `./test-desktop-audio.sh` to play a sample sound.
+- Reset routing with `./fix-audio-routing.sh` if devices are misconfigured.
+
+## Monitoring
+
+- `./audio-monitor.sh` shows real-time PulseAudio status.
+- `./debug-audio-pipeline.sh` prints detailed pipeline information.
+
+## Related Documentation
+
+- [General Audio Setup](README_AUDIO.md)
+- [Troubleshooting Guide](TROUBLESHOOTING.md)

--- a/ubuntu-kde-docker/README.md
+++ b/ubuntu-kde-docker/README.md
@@ -396,7 +396,8 @@ This project is licensed under the MIT License - see the LICENSE file for detail
 - **[Validation Guide](VALIDATION.md)**: Comprehensive system validation and testing
 - **[Troubleshooting Guide](TROUBLESHOOTING.md)**: Advanced troubleshooting and recovery
 - **[Service Architecture](SERVICES.md)**: Detailed service documentation and management
-- **[Audio Configuration](#-audio-configuration)**: Container-compatible audio setup
+- **[Audio Diagnostics](AUDIO_DIAGNOSTICS.md)**: Detailed audio troubleshooting and validation
+- **[Audio Configuration](README_AUDIO.md)**: Container-compatible audio setup
 
 ## 🆘 Support
 

--- a/ubuntu-kde-docker/docs/MULTI_CONTAINER.md
+++ b/ubuntu-kde-docker/docs/MULTI_CONTAINER.md
@@ -2,6 +2,9 @@
 
 This guide covers how to deploy and manage multiple Ubuntu KDE containers for different clients, teams, or environments using the enhanced webtop.sh script.
 
+- For authentication details, see [Authentication & Security Guide](AUTHENTICATION.md).
+- For audio troubleshooting across containers, see [Audio Diagnostics](../AUDIO_DIAGNOSTICS.md).
+
 ## Overview
 
 The multi-container feature allows you to:


### PR DESCRIPTION
## Summary
- add audio diagnostics guide with common checks and monitoring tools
- link audio diagnostics guide from multi-container deployment doc and main README docs list
- switch audio configuration link to README_AUDIO.md for consistent cross-links

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_b_6899145967e4832fa42c33c114f5671e