### PR TITLE
Stabilize PulseAudio and AudioBridge startup

### DIFF
--- a/ubuntu-kde-docker/Dockerfile
+++ b/ubuntu-kde-docker/Dockerfile
@@ -205,6 +205,34 @@ RUN echo "Validating script dependencies..." && \
     /usr/local/bin/audio-monitor.sh \
     /usr/local/bin/audio-validation.sh
 
+# Audio topology + AudioBridge wrapper
+COPY pulse-ensure.sh /usr/local/bin/pulse-ensure.sh
+COPY audio-bridge-wrapper.sh /usr/local/bin/audio-bridge-wrapper.sh
+RUN chmod +x /usr/local/bin/pulse-ensure.sh /usr/local/bin/audio-bridge-wrapper.sh
+
+# PulseAudio daemon tuning (stable timing, bigger buffers, avoid-resampling)
+RUN printf "%s\n" \
+  "default-sample-format = s16le" \
+  "default-sample-rate = 48000" \
+  "alternate-sample-rate = 44100" \
+  "avoid-resampling = yes" \
+  "resample-method = soxr-vhq" \
+  "realtime-scheduling = yes" \
+  "high-priority = yes" \
+  "nice-level = -11" \
+  "rlimit-rtprio = 9" \
+  "rlimit-rttime = 200000" \
+  "flat-volumes = no" \
+  "disable-remixing = yes" \
+  "enable-lfe-remixing = no" \
+  "remixing-produce-lfe = no" \
+  "remixing-consume-lfe = no" \
+  "enable-deferred-volume = no" \
+  "default-fragments = 8" \
+  "default-fragment-size-msec = 40" \
+  "exit-idle-time = -1" \
+  > /etc/pulse/daemon.conf
+
 COPY supervisord.conf /etc/supervisor/conf.d/supervisord.conf
 
 # Copy PolicyKit configuration files for Ubuntu 24.04 bug fix

--- a/ubuntu-kde-docker/audio-bridge-wrapper.sh
+++ b/ubuntu-kde-docker/audio-bridge-wrapper.sh
@@ -1,0 +1,28 @@
+#!/usr/bin/env bash
+set -Eeuo pipefail
+DESK_USER="${DESK_USER:-${DEV_USERNAME:-devuser}}"
+
+uid="$(getent passwd "$DESK_USER" | cut -d: -f3 || true)"
+[ -n "${uid}" ] || { echo "[wrapper] user not found: $DESK_USER"; exit 1; }
+
+export XDG_RUNTIME_DIR="/run/user/${uid}"
+export HOME="/home/${DESK_USER}"
+export PULSE_SERVER="unix:${XDG_RUNTIME_DIR}/pulse/native"
+export PULSE_LATENCY_MSEC="${PULSE_LATENCY_MSEC:-180}"
+
+echo "[wrapper] waiting for PulseAudio on ${PULSE_SERVER} (user=${DESK_USER})"
+for i in {1..120}; do
+  if su -s /bin/bash "$DESK_USER" -c "PULSE_SERVER='$PULSE_SERVER' pactl info" >/dev/null 2>&1; then
+    break
+  fi
+  (( i % 20 == 0 )) && echo "[wrapper] still waiting (${i}s)..."
+  sleep 1
+done
+
+echo "[wrapper] starting AudioBridge as ${DESK_USER}"
+exec su -s /bin/bash "$DESK_USER" -c "exec env \
+  XDG_RUNTIME_DIR='${XDG_RUNTIME_DIR}' \
+  HOME='${HOME}' \
+  PULSE_SERVER='${PULSE_SERVER}' \
+  PULSE_LATENCY_MSEC='${PULSE_LATENCY_MSEC}' \
+  node /opt/audio-bridge/server.js"

--- a/ubuntu-kde-docker/pulse-ensure.sh
+++ b/ubuntu-kde-docker/pulse-ensure.sh
@@ -1,0 +1,64 @@
+#!/usr/bin/env bash
+# Purpose: converge Pulse topology without restarting Pulse.
+# - Use the desktop user's unix socket (preferred)
+# - Ensure exactly one virtual_speaker @ 48k s16le 2ch with latency_msec
+# - Set defaults (sink=virtual_speaker, source=virtual_speaker.monitor)
+# - Remove duplicate *.2 sinks safely
+set -Eeuo pipefail
+DESK_USER="${1:-devuser}"
+TARGET_RATE="${PULSE_RATE:-48000}"
+TARGET_FORMAT="${PULSE_FORMAT:-s16le}"
+TARGET_CHANNELS="${PULSE_CHANNELS:-2}"
+TARGET_NULL_LATENCY_MS="${NULL_LATENCY_MSEC:-200}"
+
+uid="$(getent passwd "$DESK_USER" | cut -d: -f3)"
+[ -n "${uid}" ] || { echo "[pulse-ensure] unknown user ${DESK_USER}"; exit 0; }
+export XDG_RUNTIME_DIR="/run/user/${uid}"
+export PULSE_SERVER="unix:${XDG_RUNTIME_DIR}/pulse/native"
+
+su -s /bin/bash "$DESK_USER" -c "pactl info" >/dev/null 2>&1 || {
+  echo "[pulse-ensure] Pulse not ready for ${DESK_USER}"; exit 0; }
+
+# unload modules that degrade quality (non-fatal)
+su -s /bin/bash "$DESK_USER" -c \
+  "pactl list short modules | awk '/module-suspend-on-idle|module-echo-cancel/ {print \$1}' | xargs -r -I{} pactl unload-module {}" || true
+
+# remove duplicate sinks named *.N for known bases
+for base in virtual_speaker virtual_microphone fallback_speaker fallback_microphone; do
+  su -s /bin/bash "$DESK_USER" -c \
+    "pactl list short sinks | awk -v p=\"^${base}\\.[0-9]+$\" '\$2 ~ p {print \$2}'" \
+  | while read -r dup; do
+      mod="$(su -s /bin/bash "$DESK_USER" -c \
+        "pactl list sinks | awk -v n=\"$dup\" 'BEGIN{hit=0} /^Name: /{hit=(\$2==n)} hit&&/Owner Module:/ {print \$3; exit}'" || true)"
+      [ -n "$mod" ] && su -s /bin/bash "$DESK_USER" -c "pactl unload-module $mod" || true
+    done
+done
+
+# (re)create virtual_speaker if missing or wrong spec
+need_vs=0
+if su -s /bin/bash "$DESK_USER" -c "pactl list short sinks | awk '\$2==\"virtual_speaker\"{found=1} END{exit(found?0:1)}'"; then
+  spec="$(su -s /bin/bash "$DESK_USER" -c \
+    "pactl list sinks | awk 'BEGIN{hit=0} /^Name: /{hit=(\$2==\"virtual_speaker\")} hit&&/Sample Specification:/ {for(i=3;i<=NF;i++) printf (i==3?\"\":\" \") \$i; print \"\"; exit}'" || true)"
+  echo "$spec" | grep -qiE "^${TARGET_FORMAT}[[:space:]]+${TARGET_CHANNELS}ch[[:space:]]+${TARGET_RATE}Hz$" || need_vs=1
+else
+  need_vs=1
+fi
+
+if [ "$need_vs" -eq 1 ]; then
+  # remove old one if present
+  mod="$(su -s /bin/bash "$DESK_USER" -c \
+    "pactl list sinks | awk 'BEGIN{hit=0;mod=\"\"} /^Name: /{hit=(\$2==\"virtual_speaker\")} hit&&/Owner Module:/ {print \$3; exit}'" || true)"
+  [ -n "$mod" ] && su -s /bin/bash "$DESK_USER" -c "pactl unload-module $mod" || true
+
+  su -s /bin/bash "$DESK_USER" -c "pactl load-module module-null-sink \
+    sink_name=virtual_speaker rate=${TARGET_RATE} channels=${TARGET_CHANNELS} format=${TARGET_FORMAT} latency_msec=${TARGET_NULL_LATENCY_MS} \
+    sink_properties=device.description=Virtual_Speaker >/dev/null"
+fi
+
+# defaults + sane volume
+su -s /bin/bash "$DESK_USER" -c "pactl set-default-sink virtual_speaker" || true
+if su -s /bin/bash "$DESK_USER" -c "pactl list short sources | awk '\$2==\"virtual_speaker.monitor\"{exit 0} END{exit 1}'"; then
+  su -s /bin/bash "$DESK_USER" -c "pactl set-default-source virtual_speaker.monitor" || true
+fi
+su -s /bin/bash "$DESK_USER" -c "pactl set-sink-mute virtual_speaker 0" || true
+su -s /bin/bash "$DESK_USER" -c "pactl set-sink-volume virtual_speaker 70%" || true

--- a/ubuntu-kde-docker/supervisord.conf
+++ b/ubuntu-kde-docker/supervisord.conf
@@ -163,17 +163,15 @@ stdout_logfile=/var/log/supervisor/health.log
 stderr_logfile=/var/log/supervisor/health.log
 
 [program:CreateVirtualAudioDevices]
-command=/bin/bash /usr/local/bin/create-virtual-audio-devices.sh
+command=/usr/local/bin/pulse-ensure.sh %(ENV_DEV_USERNAME)s
 user=root
 autostart=true
 autorestart=false
 startsecs=0
-startretries=0
 stdout_logfile=/var/log/supervisor/audio-devices.log
 stderr_logfile=/var/log/supervisor/audio-devices.log
-environment=DEV_USERNAME="%(ENV_DEV_USERNAME)s",DEV_UID="%(ENV_DEV_UID)s",DEV_GID="%(ENV_DEV_GID)s",XDG_RUNTIME_DIR="/run/user/%(ENV_DEV_UID)s"
-priority=400
-depends_on=pulseaudio
+environment=DEV_USERNAME="%(ENV_DEV_USERNAME)s",DEV_UID="%(ENV_DEV_UID)s"
+priority=26
 exitcodes=0
 
 [program:SetupDesktop]
@@ -194,7 +192,7 @@ depends_on=noVNC
 exitcodes=0
 
 [program:AudioBridge]
-command=/usr/bin/node /opt/audio-bridge/server.js
+command=/usr/local/bin/audio-bridge-wrapper.sh
 priority=25
 autostart=true
 autorestart=true
@@ -203,6 +201,7 @@ user=root
 startsecs=3
 stdout_logfile=/var/log/supervisor/audio-bridge.log
 stderr_logfile=/var/log/supervisor/audio-bridge.log
+environment=DEV_USERNAME="%(ENV_DEV_USERNAME)s",DEV_UID="%(ENV_DEV_UID)s"
 
 [program:SystemValidation]
 command=/bin/sh -c "sleep 120; /usr/local/bin/system-validation.sh --optimized"


### PR DESCRIPTION
## Summary
- add pulse-ensure.sh to converge PulseAudio sinks and defaults without restarts
- start audio bridge via wrapper that waits for the desktop user's Pulse socket
- tune system PulseAudio daemon and wire scripts into Docker and supervisord

## Testing
- `bash -n ubuntu-kde-docker/pulse-ensure.sh`
- `bash -n ubuntu-kde-docker/audio-bridge-wrapper.sh`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_6899d0f5ee6c832f881fefb0aa6b660a