### PR TITLE
Ensure AudioBridge waits for virtual audio devices

### DIFF
--- a/ubuntu-kde-docker/audio-bridge-wrapper.sh
+++ b/ubuntu-kde-docker/audio-bridge-wrapper.sh
@@ -17,6 +17,22 @@ for i in {1..120}; do
   sleep 1
 done
 
+# Ensure virtual_speaker monitor exists before starting bridge
+echo "[wrapper] waiting for virtual_speaker monitor"
+monitor_found=false
+for i in {1..60}; do
+  if pactl --server="${PULSE_SERVER}" list short sources 2>/dev/null | grep -q 'virtual_speaker.monitor'; then
+    echo "[wrapper] virtual_speaker monitor detected"
+    monitor_found=true
+    break
+  fi
+  (( i % 15 == 0 )) && echo "[wrapper] still waiting for virtual_speaker.monitor (${i}s)..."
+  sleep 1
+done
+if [ "$monitor_found" = false ]; then
+  echo "[wrapper] virtual_speaker monitor not found, continuing anyway"
+fi
+
 uid=""
 if command -v getent >/dev/null 2>&1; then
   uid="$(getent passwd "$DESK_USER" | cut -d: -f3 || true)"

--- a/ubuntu-kde-docker/supervisord.conf
+++ b/ubuntu-kde-docker/supervisord.conf
@@ -167,7 +167,7 @@ command=/usr/local/bin/pulse-ensure.sh %(ENV_DEV_USERNAME)s
 user=root
 autostart=true
 autorestart=false
-startsecs=0
+startsecs=5
 stdout_logfile=/var/log/supervisor/audio-devices.log
 stderr_logfile=/var/log/supervisor/audio-devices.log
 environment=DEV_USERNAME="%(ENV_DEV_USERNAME)s",DEV_UID="%(ENV_DEV_UID)s"
@@ -193,7 +193,7 @@ exitcodes=0
 
 [program:AudioBridge]
 command=/usr/local/bin/audio-bridge-wrapper.sh
-priority=25
+priority=30
 autostart=true
 autorestart=true
 stopsignal=TERM


### PR DESCRIPTION
## Summary
- wait for the `virtual_speaker` monitor before launching AudioBridge
- start AudioBridge after virtual audio devices are created

## Testing
- `npm ci`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_689a0108ce6c832fa43f64b02042aee2