### PR TITLE
Allow diagnostic script failure in ubuntu-kde entrypoint

### DIFF
--- a/ubuntu-kde-docker/Dockerfile
+++ b/ubuntu-kde-docker/Dockerfile
@@ -256,7 +256,7 @@ RUN chmod +x /entrypoint.sh /tmp/xstartup
 RUN test -x /usr/local/bin/diagnostic-and-fix.sh
 
 # Run diagnostic-and-fix.sh before entrypoint.sh
-ENTRYPOINT ["/bin/bash", "-c", "/usr/local/bin/diagnostic-and-fix.sh && exec /entrypoint.sh"]
+ENTRYPOINT ["/bin/bash", "-c", "/usr/local/bin/diagnostic-and-fix.sh || true; exec /entrypoint.sh"]
 
 EXPOSE 22 80 5901 7681
 


### PR DESCRIPTION
## Summary
- run diagnostics in Docker entrypoint without aborting on errors

## Testing
- `apt-get update`
- `apt-get install -y docker.io`
- Attempted `docker build -t ubuntu-kde-test ubuntu-kde-docker` *(fails: Cannot connect to the Docker daemon at unix:///var/run/docker.sock)*

------
https://chatgpt.com/codex/tasks/task_b_689a2e2d45dc832fac0349cb0f8c63df