### PR TITLE
feat: switch audio bridge to 48kHz

### DIFF
--- a/ubuntu-kde-docker/setup-audio-bridge.sh
+++ b/ubuntu-kde-docker/setup-audio-bridge.sh
@@ -94,11 +94,11 @@ wss.on('connection', (ws) => {
         const monitor = detectMonitor();
         console.log(`\uD83D\uDD0A Starting recording from monitor: ${monitor}`);
         const parecordOptions = [
-            ['--device=' + monitor, '--format=s16le', '--rate=44100', '--channels=2', '--raw'],
-            ['--device=@DEFAULT_MONITOR@', '--format=s16le', '--rate=44100', '--channels=2', '--raw'],
-            ['--server=tcp:localhost:4713', '--device=' + monitor, '--format=s16le', '--rate=44100', '--channels=2', '--raw'],
-            ['--server=tcp:localhost:4713', '--device=@DEFAULT_MONITOR@', '--format=s16le', '--rate=44100', '--channels=2', '--raw'],
-            ['--server=tcp:localhost:4713', '--format=s16le', '--rate=44100', '--channels=2', '--raw']
+            ['--device=' + monitor, '--format=s16le', '--rate=48000', '--channels=2', '--raw'],
+            ['--device=@DEFAULT_MONITOR@', '--format=s16le', '--rate=48000', '--channels=2', '--raw'],
+            ['--server=tcp:localhost:4713', '--device=' + monitor, '--format=s16le', '--rate=48000', '--channels=2', '--raw'],
+            ['--server=tcp:localhost:4713', '--device=@DEFAULT_MONITOR@', '--format=s16le', '--rate=48000', '--channels=2', '--raw'],
+            ['--server=tcp:localhost:4713', '--format=s16le', '--rate=48000', '--channels=2', '--raw']
         ];
         
         let optionIndex = 0;


### PR DESCRIPTION
## Summary
- update parecord options to record at 48kHz instead of 44.1kHz
- regenerate audio bridge server to use 48kHz sample rate

## Testing
- `node --test ubuntu-kde-docker/test/audio-bridge.test.cjs`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_689a5213fd70832f94b2b33d0060bd6a