### PR TITLE
Increase PulseAudio latency to 180ms

### DIFF
--- a/ubuntu-kde-docker/audio-bridge-wrapper.sh
+++ b/ubuntu-kde-docker/audio-bridge-wrapper.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 set -euo pipefail
 export PULSE_SERVER='tcp:127.0.0.1:4713'
-export PULSE_LATENCY_MSEC='60'
+export PULSE_LATENCY_MSEC='180'
 
 echo "[wrapper] waiting for PulseAudio on ${PULSE_SERVER}"
 for i in {1..90}; do


### PR DESCRIPTION
## Summary
- raise PULSE_LATENCY_MSEC to 180ms in audio-bridge wrapper for smoother audio

## Testing
- `npm test`
- `docker-compose -f ubuntu-kde-docker/docker-compose.yml build webtop` *(fails: Couldn't find env file)*

------
https://chatgpt.com/codex/tasks/task_b_689a54608a90832f8e611be8cbcf4c72