### PR TITLE
feat: bump universal audio sample rate

### DIFF
--- a/ubuntu-kde-docker/universal-audio.js
+++ b/ubuntu-kde-docker/universal-audio.js
@@ -475,7 +475,11 @@
                 const samples = new Int16Array(data);
                 if (samples.length === 0) return;
 
-                const audioBuffer = this.audioContext.createBuffer(2, samples.length / 2, 44100);
+                const audioBuffer = this.audioContext.createBuffer(
+                    2,
+                    samples.length / 2,
+                    48000
+                );
                 const leftChannel = audioBuffer.getChannelData(0);
                 const rightChannel = audioBuffer.getChannelData(1);
 


### PR DESCRIPTION
## Summary
- raise universal audio buffer sample rate to 48 kHz

## Testing
- `npm test`
- `bash ubuntu-kde-docker/setup-universal-audio.sh`


------
https://chatgpt.com/codex/tasks/task_b_689a55c0b9ac832f8c977d592fe3b42e