### PR TITLE
Add virtual audio device program and enhance AudioBridge config

### DIFF
--- a/ubuntu-kde-docker/supervisord.conf
+++ b/ubuntu-kde-docker/supervisord.conf
@@ -142,7 +142,17 @@ exitcodes=0
 startsecs=0
 stdout_logfile=/var/log/supervisor/audio-validation.log
 stderr_logfile=/var/log/supervisor/audio-validation.log
-
+[program:CreateVirtualAudioDevices]
+command=/usr/local/bin/pulse-ensure.sh %(ENV_DEV_USERNAME)s
+priority=26
+autostart=true
+autorestart=false
+user=root
+startretries=1
+startsecs=0
+exitcodes=0
+stdout_logfile=/var/log/supervisor/create-virtual-audio-devices.log
+stderr_logfile=/var/log/supervisor/create-virtual-audio-devices.log
 
 [program:AudioMonitor]
 command=/bin/sh -c "sleep 60; /usr/local/bin/audio-monitor.sh monitor"
@@ -211,7 +221,8 @@ autorestart=true
 stopsignal=TERM
 user=root
 startsecs=3
-depends_on=PulseAudioDaemon
+depends_on=PulseAudioDaemon,CreateVirtualAudioDevices
+environment=PULSE_SERVER=tcp:127.0.0.1:4713,PULSE_LATENCY_MSEC=180,DEV_USERNAME="%(ENV_DEV_USERNAME)s",DEV_UID="%(ENV_DEV_UID)s"
 stdout_logfile=/var/log/supervisor/audio-bridge.log
 stderr_logfile=/var/log/supervisor/audio-bridge.log
 
@@ -233,7 +244,7 @@ programs=Xvfb,dbus,accounts-daemon
 priority=10
 
 [group:audio]
-programs=SetupPulseTCP,SetupPulseAudio,PulseAudioDaemon,AudioValidation,AudioMonitor,AudioBridge
+programs=SetupPulseTCP,SetupPulseAudio,PulseAudioDaemon,AudioValidation,CreateVirtualAudioDevices,AudioMonitor,AudioBridge
 priority=25
 
 [group:desktop]


### PR DESCRIPTION
## Summary
- add CreateVirtualAudioDevices program to create PulseAudio virtual devices
- configure AudioBridge with PulseAudio environment and dependency on new program
- include CreateVirtualAudioDevices in audio supervisor group

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_689a77c2bdec832f80d7dbf6e3a7b9b1